### PR TITLE
Circleci iOS build cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,8 +176,8 @@ jobs:
       # Fetch CocoaPods specs
       - run: curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
 
-      # Setup react-native-config
-      - run: ./bin/add-ios-env-config.sh
+      # Re-run postinstall scripts (setup of react-native libs)
+      - run: npm run postinstall
 
       # Move to the ios project directory and run the test_build lane
       - run: cd ios && bundle exec fastlane test_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,4 +169,7 @@ workflows:
             - build-android-bundle
 
       # Test iOS
-      - test-ios
+      - test-ios:
+          requires:
+            - test-js-node-8
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,6 @@ jobs:
     steps:
       - checkout
 
-      # Creates test .env file
-      - run: cp .env.example .env
-
       # Restore dependencies
       - restore_cache:
           keys:
@@ -178,6 +175,9 @@ jobs:
 
       # Fetch CocoaPods specs
       - run: curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
+
+      # Setup react-native-config
+      - run: ./bin/add-ios-env-config.sh
 
       # Move to the ios project directory and run the test_build lane
       - run: cd ios && bundle exec fastlane test_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,13 @@ jobs:
     working_directory: /Users/distiller/italia-app
 
     environment:
+      # Fastlane requires locale set to UTF-8
+      # see https://docs.fastlane.tools/getting-started/ios/setup/#set-up-environment-variables
+      LC_ALL: en_US.UTF-8
+      LANG: en_US.UTF-8
+      # Set Fastlane output dir
       FL_OUTPUT_DIR: output
+      # Make Ruby bundler a little faster
       BUNDLE_JOBS: 3
       BUNDLE_RETRY: 3
       BUNDLE_PATH: vendor/bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,16 +134,29 @@ jobs:
     shell: /bin/bash --login -o pipefail
 
     steps:
-      - checkout
+      # Restore workflow workspace
+      - attach_workspace:
+          at: /home/circleci
 
-      # Download node packages
-      - run: yarn install
+      # Restore bundle cache
+      - restore_cache:
+          keys:
+            - ruby-{{ checksum "Gemfile.lock" }}
+            - ruby-
 
       # Set Ruby Version for chruby
       - run: echo "ruby-2.4" > .ruby-version
 
-      # Install bundles
-      - run: bundle install
+      # Install bundle dependencies
+      - run:
+          name: Bundle Install
+          command: bundle check || bundle install
+
+      # Store bundle cache
+      - save_cache:
+          key: ruby-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
 
       # Fetch CocoaPods specs
       - run: curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ defaults: &defaults
 
 defaults_js: &defaults_js
   <<: *defaults
+  parallelism: 2
   docker:
     - image: circleci/node:8
 
@@ -131,12 +132,20 @@ jobs:
     macos:
       xcode: "9.0"
 
+    working_directory: /Users/distiller/italia-app
+
+    environment:
+      FL_OUTPUT_DIR: output
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: vendor/bundle
+
     shell: /bin/bash --login -o pipefail
 
     steps:
       # Restore workflow workspace
       - attach_workspace:
-          at: /home/circleci
+          at: /Users/distiller
 
       # Restore bundle cache
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - checkout
 
+      # Creates test .env file
+      - run: cp .env.example .env
+
       # Restore dependencies
       - restore_cache:
           keys:

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ buck-out/
 
 # Visual Studio Code settings
 .vscode
+
+# Bundler
+vendor


### PR DESCRIPTION
Enables parallel execution of ios and android pipelines, reuse node workspace (with yarn deps) in ios build, adds cache for ruby gems