### PR TITLE
Fixes duplicated IdentityProvider definition

### DIFF
--- a/ts/api/index.ts
+++ b/ts/api/index.ts
@@ -5,17 +5,6 @@
 
 import { apiUrlPrefix } from "../config";
 
-/**
- * Describes a SPID Identity Provider
- */
-export type IdentityProvider = {
-  id: string;
-  logo: any;
-  name: string;
-  entityID: string;
-  profileUrl: string;
-};
-
 export type ApiFetchSuccess<T> = {
   isError: false;
   result: T;

--- a/ts/components/IdpsGrid.tsx
+++ b/ts/components/IdpsGrid.tsx
@@ -9,7 +9,7 @@ import {
 
 import { Button, View } from "native-base";
 
-import { IdentityProvider } from "../utils/api";
+import { IdentityProvider } from "../models/IdentityProvider";
 
 import variables from "../theme/variables";
 

--- a/ts/models/IdentityProvider.ts
+++ b/ts/models/IdentityProvider.ts
@@ -1,0 +1,15 @@
+/**
+ * Describes a SPID Identity Provider
+ */
+
+export type IdentityProvider = {
+  id: string;
+  logo: any;
+  name: string;
+  entityID: string;
+  profileUrl: string;
+};
+
+export function isDemoIdp(idp: IdentityProvider): boolean {
+  return idp.id === "demo";
+}

--- a/ts/screens/authentication/IdpSelectionScreen.tsx
+++ b/ts/screens/authentication/IdpSelectionScreen.tsx
@@ -18,8 +18,8 @@ import IdpsGrid from "../../components/IdpsGrid";
 import AppHeader from "../../components/ui/AppHeader";
 import * as config from "../../config";
 import I18n from "../../i18n";
+import { IdentityProvider } from "../../models/IdentityProvider";
 import { selectIdp } from "../../store/actions/session";
-import { IdentityProvider } from "../../utils/api";
 type ReduxMappedProps = {};
 type OwnProps = {
   navigation: NavigationScreenProp<NavigationState>;

--- a/ts/store/actions/session.ts
+++ b/ts/store/actions/session.ts
@@ -4,7 +4,7 @@
  * @flow
  */
 
-import { IdentityProvider } from "../../api";
+import { IdentityProvider } from "../../models/IdentityProvider";
 import { IDP_SELECTED, LOGIN_FAILURE, LOGIN_SUCCESS } from "./constants";
 
 // Actions

--- a/ts/store/reducers/session.ts
+++ b/ts/store/reducers/session.ts
@@ -3,7 +3,7 @@
  */
 
 import { Action } from "../../actions/types";
-import { IdentityProvider } from "../../api";
+import { IdentityProvider } from "../../models/IdentityProvider";
 import { GlobalState } from "../../reducers/types";
 import { IDP_SELECTED, LOGIN_SUCCESS } from "../actions/constants";
 

--- a/ts/utils/api.ts
+++ b/ts/utils/api.ts
@@ -69,18 +69,3 @@ export async function setUserProfile(
     // @see https://www.pivotaltracker.com/story/show/154661120
   }
 }
-
-/**
- * Describes a SPID Identity Provider
- */
-export type IdentityProvider = {
-  id: string;
-  logo: any;
-  name: string;
-  entityID: string;
-  profileUrl: string;
-};
-
-export function isDemoIdp(idp: IdentityProvider): boolean {
-  return idp.id === "demo";
-}


### PR DESCRIPTION
There were two identical definitions for `IdentityProvider`, I've refactored the code to have just one.