### PR TITLE
Using the proper system email keyboard on email input fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Il flusso di autenticazione è il seguente:
 3. Shibboleth prende in carico il processo di autenticazione verso l'IdP
 4. Ad autenticazione avvenuta, viene fatto un redirect dall'IdP all'endpoint del backend che si occupa della generazione di un nuovo token di sessione.
 5. L'endpoint di generazione di un nuovo token riceve via header HTTP gli attributi SPID, poi genera un nuovo token di sessione (es. `123456789`) e restituisce alla webview un HTTP redirect verso un URL _well known_, contenente il token di sessione (es. `/api/token/123456789`)
-6. L'app, che controlla la webview, intercetta questo URL prima che venga effettuata la richiesta HTTP, ne estrae il token di sessione e termina il flusso di autenticazione chiudendo la webview.  
+6. L'app, che controlla la webview, intercetta questo URL prima che venga effettuata la richiesta HTTP, ne estrae il token di sessione e termina il flusso di autenticazione chiudendo la webview.
 
 Successivamente il token di sessione viene usato dall'app per effettuare le chiamate all'API di backend (es. per ottenere gli attributi SPID).
 
@@ -80,19 +80,34 @@ Successivamente il token di sessione viene usato dall'app per effettuare le chia
 
 ### Pre-requisiti
 
-#### Nodenv
+#### nodenv
 
-Su macOS e Linux si consiglia l'uso di [nodenv](https://github.com/nodenv/nodenv) per la gestione di versione multiple di NodeJS.
+Su macOS e Linux si consiglia l'uso di [nodenv](https://github.com/nodenv/nodenv)
+per la gestione di versione multiple di NodeJS.
 
-La versione di node usata nel progetto [è questa](https://github.com/teamdigitale/ItaliaApp/blob/master/.node-version).
+La versione di node usata nel progetto [è questa](.node-version).
 
-#### Yarn
+Se si ha già `nodenv` installato e configurato sul proprio sistema, la versione
+di `node` corretta verrà impostata quando si accede alla directory dell'app.
 
-Per la gestione delle dipendenze usiamo [Yarn](https://yarnpkg.com/lang/en/).
+#### yarn
+
+Per la gestione delle dipendenze javascript usiamo
+[Yarn](https://yarnpkg.com/lang/en/).
 
 #### rbenv
 
-Alcune dipendenze (es. CocoaPods) sono installate tramite [rbenv](https://github.com/rbenv/rbenv).
+Su macOS e Linux si consiglia l'uso di [rbenv](https://github.com/rbenv/rbenv)
+per la gestione di versione multiple di Ruby.
+
+La versione di Ruby usata nel progetto [è questa](.ruby-version).
+
+Se si ha già `rbenv` installato e configurato sul proprio sistema, la versione
+di Ruby corretta verrà impostata quando si accede alla directory dell'app.
+
+#### Bundler
+
+Alcune dipendenze (es. CocoaPods) sono installate tramite [bundler](https://bundler.io/).
 
 #### React Native
 
@@ -100,44 +115,55 @@ Seguire [il tutorial (Building Projects with Native Code)](https://facebook.gith
 
 Se si dispone di un sistema macOS è possibile seguire sia il tutorial per iOS che per Android. Se invece si dispone di un sistema Linux o Windows sarà possibile installare solo l'ambiente di sviluppo per Android.
 
-### Compilazione (dev)
+### Compilazione e lancio sul simulatore
+
+#### Dipendenze
 
 Per prima cosa installiamo le librerie usate dal progetto:
 
 ```
-$ cd ItaliaApp
-
-$ nodenv install
-$ rbenv install
-
-$ gem install bundler
 $ bundle install
-
-$ yarn
-
+$ yarn install
 $ cd ios
 $ pod install
 ```
 
-E poi compiliamo e lanciamo l'app su Android:
+#### Generazione definizioni API
+
+Il secondo passo è generare le definizioni dalle specifiche openapi:
+
+```
+$ yarn generate:api-definitions
+```
+
+#### Configurazione dell'app
+
+Infine copiamo la configurazione di esempio per l'app.
+
+```
+$ cp .env.example .env
+```
+
+Nota: la configurazione di esempio imposta l'app per interfacciarsi al nostro
+ambiente di test, su cui lavoriamo continuamente - potrebbe quindi accadere
+che alcune funzionalità non siano sempre disponibili o completamente
+funzionanti.
+
+#### Installazione sul simulatore
+
+Su Android (il simulatore del device va [lanciato a mano](https://medium.com/@deepak.gulati/running-react-native-app-on-the-android-emulator-11bf309443eb)):
 
 ```
 $ react-native run-android
 ```
 
-Oppure su iOS:
+Su iOS (il simulatore verrà lanciato automaticamente):
 
 ```
 $ react-native run-ios
 ```
 
-Nota: L'app utilizza [CocoaPods](https://cocoapods.org/), il progetto da eseguire è quindi `ItaliaApp.xcworkspace` anzichè `ItaliaApp.xcodeproj` (`run-ios` lo rileva automaticamente)
-
-### Configurazione
-```
-$ cp .env.example .env
-```
-Inseriamo il MixPanel token
+Nota: l'app utilizza [CocoaPods](https://cocoapods.org/), il progetto da eseguire è quindi `ItaliaApp.xcworkspace` anzichè `ItaliaApp.xcodeproj` (`run-ios` lo rileva automaticamente)
 
 ### Compilazione (release)
 
@@ -204,7 +230,7 @@ Inserire al posto di `XXXXX`:
 
 ##### Installazione del certificato di mitmproxy all'interno dell'emulatore Android
 
-Installare il certificato di mitmproxy all'interno dell'emulatore seguendo la [giuda](https://docs.mitmproxy.org/stable/concepts-certificates/) ufficiale. 
+Installare il certificato di mitmproxy all'interno dell'emulatore seguendo la [giuda](https://docs.mitmproxy.org/stable/concepts-certificates/) ufficiale.
 
 #### Impostare il proxy per la connessione nell'emulatore Android
 
@@ -226,7 +252,7 @@ Per aggiungere una nuova lingua è necessario:
 1. Creare un nuovo file all'interno della directory `locales` usando come nome `<langcode>.json` (Es: `es.json`)
 2. Copiare il contenuto di uno degli altri file `.json` già presenti
 3. Procedere con la traduzione
-4. Modificare il file `ts/i18n.ts` aggiungendo tra gli import e nella variabile `I18n.translations` la nuova lingua 
+4. Modificare il file `ts/i18n.ts` aggiungendo tra gli import e nella variabile `I18n.translations` la nuova lingua
 
 
 ### Gestione degli errori

--- a/ts/components/forms/SpidInformationForm.tsx
+++ b/ts/components/forms/SpidInformationForm.tsx
@@ -1,7 +1,7 @@
 import { Form } from "native-base";
 import * as React from "react";
 import { TextInput } from "react-native";
-import { Field, InjectedFormProps, reduxForm } from "redux-form";
+import { InjectedFormProps, reduxForm } from "redux-form";
 import {
   getTraslatedFormFieldPropertyValue,
   renderNativeBaseInput,

--- a/ts/components/forms/SpidInformationForm.tsx
+++ b/ts/components/forms/SpidInformationForm.tsx
@@ -25,8 +25,8 @@ class SpidInformationForm extends React.Component<InjectedFormProps, never> {
           placeholder={getCurrentFormFieldProperty("email")("placeholder")}
           validate={[validators.email]}
           showError={true}
-          keyboardType="email-address"
-          autoCapitalize="none"
+          keyboardType={"email-address" as "email-address"}
+          autoCapitalize={"none" as "none"}
         />
       </Form>
     );

--- a/ts/components/forms/SpidInformationForm.tsx
+++ b/ts/components/forms/SpidInformationForm.tsx
@@ -25,6 +25,8 @@ class SpidInformationForm extends React.Component<InjectedFormProps, never> {
           placeholder={getCurrentFormFieldProperty("email")("placeholder")}
           validate={[validators.email]}
           showError={true}
+          // TODO: Check wich type definition force us to disable tslint
+          // @https://www.pivotaltracker.com/story/show/157846397
           /* tslint:disable */
           keyboardType={"email-address" as "email-address"}
           autoCapitalize={"none" as "none"}

--- a/ts/components/forms/SpidInformationForm.tsx
+++ b/ts/components/forms/SpidInformationForm.tsx
@@ -1,5 +1,6 @@
 import { Form } from "native-base";
 import * as React from "react";
+import { TextInput } from "react-native";
 import { Field, InjectedFormProps, reduxForm } from "redux-form";
 import {
   getTraslatedFormFieldPropertyValue,
@@ -19,12 +20,15 @@ class SpidInformationForm extends React.Component<InjectedFormProps, never> {
   public render() {
     return (
       <Form>
-        <Field
+        <TextInput
           name="email"
           component={renderNativeBaseInput}
           placeholder={getCurrentFormFieldProperty("email")("placeholder")}
           validate={[validators.email]}
           showError={true}
+          keyboardType='email-address'
+          autoCapitalize="none"
+          autoCorrect={false}
         />
       </Form>
     );

--- a/ts/components/forms/SpidInformationForm.tsx
+++ b/ts/components/forms/SpidInformationForm.tsx
@@ -25,8 +25,10 @@ class SpidInformationForm extends React.Component<InjectedFormProps, never> {
           placeholder={getCurrentFormFieldProperty("email")("placeholder")}
           validate={[validators.email]}
           showError={true}
+          /* tslint:disable */
           keyboardType={"email-address" as "email-address"}
           autoCapitalize={"none" as "none"}
+          /* tslint:enable */
         />
       </Form>
     );

--- a/ts/components/forms/SpidInformationForm.tsx
+++ b/ts/components/forms/SpidInformationForm.tsx
@@ -1,7 +1,6 @@
 import { Form } from "native-base";
 import * as React from "react";
-import { TextInput } from "react-native";
-import { InjectedFormProps, reduxForm } from "redux-form";
+import { Field, InjectedFormProps, reduxForm } from "redux-form";
 import {
   getTraslatedFormFieldPropertyValue,
   renderNativeBaseInput,
@@ -20,7 +19,7 @@ class SpidInformationForm extends React.Component<InjectedFormProps, never> {
   public render() {
     return (
       <Form>
-        <TextInput
+        <Field
           name="email"
           component={renderNativeBaseInput}
           placeholder={getCurrentFormFieldProperty("email")("placeholder")}
@@ -28,7 +27,6 @@ class SpidInformationForm extends React.Component<InjectedFormProps, never> {
           showError={true}
           keyboardType="email-address"
           autoCapitalize="none"
-          autoCorrect={false}
         />
       </Form>
     );

--- a/ts/components/forms/SpidInformationForm.tsx
+++ b/ts/components/forms/SpidInformationForm.tsx
@@ -26,7 +26,7 @@ class SpidInformationForm extends React.Component<InjectedFormProps, never> {
           placeholder={getCurrentFormFieldProperty("email")("placeholder")}
           validate={[validators.email]}
           showError={true}
-          keyboardType='email-address'
+          keyboardType="email-address"
           autoCapitalize="none"
           autoCorrect={false}
         />

--- a/ts/components/forms/utils.tsx
+++ b/ts/components/forms/utils.tsx
@@ -47,7 +47,7 @@ export interface NativeBaseInputProps {
   placeholder?: string;
   showError?: boolean;
   keyboardType?: KeyboardTypeOptions;
-  autoCapitalize?: string;
+  autoCapitalize?: "none" | "sentences" | "words" | "characters";
 }
 
 /**

--- a/ts/components/forms/utils.tsx
+++ b/ts/components/forms/utils.tsx
@@ -3,6 +3,8 @@
  */
 
 import { Input, Item, Text, View } from "native-base";
+import { KeyboardTypeOptions } from "react-native";
+
 import * as React from "react";
 import { WrappedFieldProps } from "redux-form";
 import { isEmail } from "validator";
@@ -44,6 +46,8 @@ export interface NativeBaseInputProps {
   name?: string;
   placeholder?: string;
   showError?: boolean;
+  keyboardType?: KeyboardTypeOptions;
+  autoCapitalize?: string;
 }
 
 /**
@@ -52,10 +56,20 @@ export interface NativeBaseInputProps {
  */
 export const renderNativeBaseInput: React.SFC<
   WrappedFieldProps & NativeBaseInputProps
-> = ({ meta: { touched, error, active }, placeholder, showError }) => (
+> = ({
+  meta: { touched, error, active },
+  placeholder,
+  showError,
+  keyboardType,
+  autoCapitalize
+}) => (
   <View>
     <Item error={error && touched} active={active}>
-      <Input placeholder={placeholder} />
+      <Input
+        placeholder={placeholder}
+        keyboardType={keyboardType || "default"}
+        autoCapitalize={autoCapitalize || "none"}
+      />
     </Item>
     {showError && error && touched && <Text>{error}</Text>}
   </View>


### PR DESCRIPTION
iOS and Android can propose to the user different keyboard types based on the requested input.

In the *Don't have SPID?* view, there is an email field that if selected presents the user a standard generic keyboard.
This commit addresses the issue:
* The presented keyboard is the email one.
* Auto capitalisation is turned off.
* Auto correction is turned off.
* To use those parameters, the `Form/Field` has been transformed into a `Form/TextInput`.

![email-keyboard-ios](https://user-images.githubusercontent.com/587988/40480596-4aeb7f16-5f4f-11e8-93bc-8b55d8c8080a.png)
![email-keyboard-android](https://user-images.githubusercontent.com/587988/40480904-1fab1dec-5f50-11e8-9af2-f0b48a82fe7c.png)
