### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ $ yarn generate:api-definitions
 
 #### Configurazione dell'app
 
+Se siete ancora nella subdirectory ios:
+
+```
+$ cd..
+```
+
 Infine copiamo la configurazione di esempio per l'app.
 
 ```


### PR DESCRIPTION
la generazione delle dipendenze ti porta nella sub ios/ dalla quale poi non è possibile trovare, senza un cd .. , la configurazione di esempio.