### PR TITLE
Makes native iOS and Android test steps optional

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,18 +190,25 @@ workflows:
       # Lint ant test Javascript
       - test-js-node-8
 
-      # Build Android bundle
-      - build-android-bundle:
+      # To avoid running too many (long) native builds and tests, this step
+      # waits the approval for the iOS and Android native tests.
+      - hold-native-tests:
+          type: approval
           requires:
             - test-js-node-8
 
-      # Test Android
+      # Build Android bundle
+      - build-android-bundle:
+          requires:
+            - hold-native-tests
+
+      # Native Android tests
       - test-android:
           requires:
             - build-android-bundle
 
-      # Test iOS
+      # Native iOS tests
       - test-ios:
           requires:
-            - test-js-node-8
+            - hold-native-tests
 


### PR DESCRIPTION
To consume less CI resources, I've made the native tests optional (there's an approval process on the circleci UI):

![image](https://user-images.githubusercontent.com/48206/40541155-ee740e48-601a-11e8-8728-4ce4e4f094df.png)
