### PR TITLE
[#158118926] Move action types to /ts/store/actions

### DIFF
--- a/ts/RootContainer.tsx
+++ b/ts/RootContainer.tsx
@@ -6,9 +6,9 @@ import { Root } from "native-base";
 
 import ConnectionBar from "./components/ConnectionBar";
 
-import { ApplicationState, ReduxProps } from "./actions/types";
 import Navigation from "./navigation";
 import { APP_STATE_CHANGE_ACTION } from "./store/actions/constants";
+import { ApplicationState, ReduxProps } from "./store/actions/types";
 
 interface ReduxMappedProps {}
 

--- a/ts/boot/configurePushNotification.ts
+++ b/ts/boot/configurePushNotification.ts
@@ -5,9 +5,9 @@
 import { Alert, PushNotificationIOS } from "react-native";
 import PushNotification from "react-native-push-notification";
 
-import { Store } from "../actions/types";
 import { debugRemotePushNotification, gcmSenderId } from "../config";
 import { updateNotificationsInstallationToken } from "../store/actions/notifications";
+import { Store } from "../store/actions/types";
 
 function configurePushNotifications(store: Store) {
   PushNotification.configure({

--- a/ts/boot/configureStoreAndPersistor.ts
+++ b/ts/boot/configureStoreAndPersistor.ts
@@ -12,11 +12,11 @@ import storage from "redux-persist/lib/storage";
 import createSagaMiddleware from "redux-saga";
 import thunk from "redux-thunk";
 
-import { Action, Store, StoreEnhancer } from "../actions/types";
 import { analytics } from "../middlewares";
 import rootReducer from "../reducers";
 import { GlobalState } from "../reducers/types";
 import rootSaga from "../sagas";
+import { Action, Store, StoreEnhancer } from "../store/actions/types";
 import { NAVIGATION_MIDDLEWARE_LISTENERS_KEY } from "../utils/constants";
 
 const isDebuggingInChrome = __DEV__ && !!window.navigator.userAgent;

--- a/ts/components/ConnectionBar.tsx
+++ b/ts/components/ConnectionBar.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import { StyleSheet, Text, View } from "react-native";
 import { connect } from "react-redux";
-import { ReduxProps } from "../actions/types";
 import I18n from "../i18n";
 import { GlobalState } from "../reducers/types";
+import { ReduxProps } from "../store/actions/types";
 export type ReduxMappedProps = {
   isConnected: boolean;
 };

--- a/ts/middlewares/analytics.ts
+++ b/ts/middlewares/analytics.ts
@@ -1,11 +1,11 @@
 import Mixpanel from "react-native-mixpanel";
 import { NavigationActions } from "react-navigation";
 
-import { Action, Dispatch, MiddlewareAPI } from "../actions/types";
 import {
   APP_STATE_CHANGE_ACTION,
   NOTIFICATIONS_INSTALLATION_UPDATE_FAILURE
 } from "../store/actions/constants";
+import { Action, Dispatch, MiddlewareAPI } from "../store/actions/types";
 
 /*
  * The middleware acts as a general hook in order to track any meaningful action

--- a/ts/navigation/index.tsx
+++ b/ts/navigation/index.tsx
@@ -8,8 +8,8 @@ import {
 import { createReduxBoundAddListener } from "react-navigation-redux-helpers";
 import { connect } from "react-redux";
 
-import { ReduxProps } from "../actions/types";
 import { GlobalState } from "../reducers/types";
+import { ReduxProps } from "../store/actions/types";
 import { NAVIGATION_MIDDLEWARE_LISTENERS_KEY } from "../utils/constants";
 import AppNavigator from "./AppNavigator";
 

--- a/ts/reducers/__tests__/appState.test.ts
+++ b/ts/reducers/__tests__/appState.test.ts
@@ -1,5 +1,5 @@
-import { ApplicationStateAction } from "../../actions/types";
 import { APP_STATE_CHANGE_ACTION } from "../../store/actions/constants";
+import { ApplicationStateAction } from "../../store/actions/types";
 import appState, { initialAppState } from "../appState";
 
 describe("appState reducer", () => {

--- a/ts/reducers/appState.ts
+++ b/ts/reducers/appState.ts
@@ -4,8 +4,8 @@
  * Handles React Native's AppState changes.
  */
 
-import { Action, ApplicationState } from "../actions/types";
 import { APP_STATE_CHANGE_ACTION } from "../store/actions/constants";
+import { Action, ApplicationState } from "../store/actions/types";
 
 export type AppState = Readonly<{
   appState: ApplicationState;

--- a/ts/reducers/index.ts
+++ b/ts/reducers/index.ts
@@ -6,7 +6,7 @@ import { reducer as networkReducer } from "react-native-offline";
 import { Reducer, ReducersMapObject } from "redux";
 import { FormStateMap, reducer as formReducer } from "redux-form";
 
-import { Action } from "../actions/types";
+import { Action } from "../store/actions/types";
 import entitiesReducer from "../store/reducers/entities";
 import errorReducer from "../store/reducers/error";
 import loadingReducer from "../store/reducers/loading";

--- a/ts/reducers/navigation.ts
+++ b/ts/reducers/navigation.ts
@@ -1,7 +1,7 @@
 import { NavigationActions, NavigationState } from "react-navigation";
 
-import { Action } from "../actions/types";
 import AppNavigator from "../navigation/AppNavigator";
+import { Action } from "../store/actions/types";
 
 const INITIAL_STATE: NavigationState = AppNavigator.router.getStateForAction(
   NavigationActions.init()

--- a/ts/reducers/types.ts
+++ b/ts/reducers/types.ts
@@ -1,7 +1,7 @@
 import { NavigationState } from "react-navigation";
 import { FormStateMap } from "redux-form";
 
-import { Action } from "../actions/types";
+import { Action } from "../store/actions/types";
 import { EntitiesState } from "../store/reducers/entities";
 import { ErrorState } from "../store/reducers/error";
 import { LoadingState } from "../store/reducers/loading";

--- a/ts/screens/IngressScreen.tsx
+++ b/ts/screens/IngressScreen.tsx
@@ -3,9 +3,9 @@ import * as React from "react";
 import { ActivityIndicator, StyleSheet } from "react-native";
 import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
-import { ReduxProps } from "../actions/types";
 import { GlobalState } from "../reducers/types";
 import { applicationInitialized } from "../store/actions/application";
+import { ReduxProps } from "../store/actions/types";
 import { SessionState } from "../store/reducers/session";
 import variables from "../theme/variables";
 type ReduxMappedProps = {

--- a/ts/screens/authentication/IdpLoginScreen.tsx
+++ b/ts/screens/authentication/IdpLoginScreen.tsx
@@ -3,12 +3,12 @@ import * as React from "react";
 import { WebView } from "react-native";
 import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
-import { ReduxProps } from "../../actions/types";
 import AppHeader from "../../components/ui/AppHeader";
 import * as config from "../../config";
 import I18n from "../../i18n";
 import { GlobalState } from "../../reducers/types";
 import { loginFailure, loginSuccess } from "../../store/actions/session";
+import { ReduxProps } from "../../store/actions/types";
 import {
   isUnauthenticatedWithoutIdpSessionState,
   SessionState

--- a/ts/screens/authentication/IdpSelectionScreen.tsx
+++ b/ts/screens/authentication/IdpSelectionScreen.tsx
@@ -13,13 +13,13 @@ import * as React from "react";
 import { Image, StyleSheet } from "react-native";
 import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
-import { ReduxProps } from "../../actions/types";
 import IdpsGrid from "../../components/IdpsGrid";
 import AppHeader from "../../components/ui/AppHeader";
 import * as config from "../../config";
 import I18n from "../../i18n";
 import { IdentityProvider } from "../../models/IdentityProvider";
 import { selectIdp } from "../../store/actions/session";
+import { ReduxProps } from "../../store/actions/types";
 type ReduxMappedProps = {};
 type OwnProps = {
   navigation: NavigationScreenProp<NavigationState>;

--- a/ts/screens/authentication/LandingScreen.tsx
+++ b/ts/screens/authentication/LandingScreen.tsx
@@ -10,10 +10,10 @@ import {
 import * as React from "react";
 import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
-import { ReduxProps } from "../../actions/types";
 import AppHeader from "../../components/ui/AppHeader";
 import I18n from "../../i18n";
 import ROUTES from "../../navigation/routes";
+import { ReduxProps } from "../../store/actions/types";
 type ReduxMappedProps = {};
 type OwnProps = {
   navigation: NavigationScreenProp<NavigationState>;

--- a/ts/screens/main/MessagesScreen.tsx
+++ b/ts/screens/main/MessagesScreen.tsx
@@ -8,11 +8,11 @@ import {
 } from "react-navigation";
 import { connect } from "react-redux";
 
-import { ReduxProps } from "../../actions/types";
 import I18n from "../../i18n";
 import { GlobalState } from "../../reducers/types";
 import { FetchRequestActions } from "../../store/actions/constants";
 import { loadMessages } from "../../store/actions/messages";
+import { ReduxProps } from "../../store/actions/types";
 import { orderedMessagesSelector } from "../../store/reducers/entities/messages";
 import { createLoadingSelector } from "../../store/reducers/loading";
 import variables from "../../theme/variables";

--- a/ts/screens/onboarding/PinScreen.tsx
+++ b/ts/screens/onboarding/PinScreen.tsx
@@ -15,13 +15,13 @@ import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
 
 import { Option } from "fp-ts/lib/Option";
-import { ReduxProps } from "../../actions/types";
 import Pinpad from "../../components/Pinpad";
 import AppHeader from "../../components/ui/AppHeader";
 import TextWithIcon from "../../components/ui/TextWithIcon";
 import I18n from "../../i18n";
 import { GlobalState } from "../../reducers/types";
 import { createPin } from "../../store/actions/onboarding";
+import { ReduxProps } from "../../store/actions/types";
 import { createErrorSelector } from "../../store/reducers/error";
 
 type ReduxMappedProps = {

--- a/ts/screens/onboarding/TosScreen.tsx
+++ b/ts/screens/onboarding/TosScreen.tsx
@@ -13,10 +13,10 @@ import {
 import * as React from "react";
 import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
-import { ReduxProps } from "../../actions/types";
 import AppHeader from "../../components/ui/AppHeader";
 import I18n from "../../i18n";
 import { acceptTos } from "../../store/actions/onboarding";
+import { ReduxProps } from "../../store/actions/types";
 type ReduxMappedProps = {};
 type OwnProps = {
   navigation: NavigationScreenProp<NavigationState>;

--- a/ts/store/actions/types.ts
+++ b/ts/store/actions/types.ts
@@ -1,5 +1,5 @@
 /**
- * Defines Flow types for the available actions and store related stuff.
+ * Defines types for the available actions and store related stuff.
  */
 
 import { NavigationAction } from "react-navigation";
@@ -10,16 +10,16 @@ import {
   StoreEnhancer as ReduxStoreEnhancer
 } from "redux";
 
-import { GlobalState } from "../reducers/types";
-import { ApplicationActions } from "../store/actions/application";
-import { APP_STATE_CHANGE_ACTION } from "../store/actions/constants";
-import { ErrorActions } from "../store/actions/error";
-import { MessagesActions } from "../store/actions/messages";
-import { NotificationsActions } from "../store/actions/notifications";
-import { OnboardingActions } from "../store/actions/onboarding";
-import { ProfileActions } from "../store/actions/profile";
-import { ServicesActions } from "../store/actions/services";
-import { SessionActions } from "../store/actions/session";
+import { GlobalState } from "../../reducers/types";
+import { ApplicationActions } from "./application";
+import { APP_STATE_CHANGE_ACTION } from "./constants";
+import { ErrorActions } from "./error";
+import { MessagesActions } from "./messages";
+import { NotificationsActions } from "./notifications";
+import { OnboardingActions } from "./onboarding";
+import { ProfileActions } from "./profile";
+import { ServicesActions } from "./services";
+import { SessionActions } from "./session";
 
 export type ApplicationState = "background" | "inactive" | "active";
 

--- a/ts/store/reducers/entities/index.ts
+++ b/ts/store/reducers/entities/index.ts
@@ -3,7 +3,7 @@
  */
 import { combineReducers } from "redux";
 
-import { Action } from "../../../actions/types";
+import { Action } from "../../actions/types";
 import messagesReducer, { MessagesState } from "./messages";
 import servicesReducer, { ServicesState } from "./services";
 

--- a/ts/store/reducers/entities/messages/index.ts
+++ b/ts/store/reducers/entities/messages/index.ts
@@ -5,8 +5,8 @@
 import { combineReducers } from "redux";
 import { createSelector } from "reselect";
 
-import { Action } from "../../../../actions/types";
 import { messagesComparatorByIdDesc } from "../../../../utils/messages";
+import { Action } from "../../../actions/types";
 import messagesAllIdsReducer, {
   messagesAllIdsSelector,
   MessagesAllIdsState

--- a/ts/store/reducers/entities/messages/messagesAllIds.ts
+++ b/ts/store/reducers/entities/messages/messagesAllIds.ts
@@ -4,9 +4,9 @@
  * are managed by different global reducers.
  */
 
-import { Action } from "../../../../actions/types";
 import { GlobalState } from "../../../../reducers/types";
 import { MESSAGE_LOAD_SUCCESS } from "../../../actions/constants";
+import { Action } from "../../../actions/types";
 
 // An array of messages id
 export type MessagesAllIdsState = ReadonlyArray<string>;

--- a/ts/store/reducers/entities/messages/messagesById.ts
+++ b/ts/store/reducers/entities/messages/messagesById.ts
@@ -4,10 +4,10 @@
  * are managed by different global reducers.
  */
 
-import { Action } from "../../../../actions/types";
 import { GlobalState } from "../../../../reducers/types";
 import { MessageWithContentPO } from "../../../../types/MessageWithContentPO";
 import { MESSAGE_LOAD_SUCCESS } from "../../../actions/constants";
+import { Action } from "../../../actions/types";
 
 // An object containing MessageWithContentPO keyed by id
 export type MessagesByIdState = Readonly<{

--- a/ts/store/reducers/entities/services/index.ts
+++ b/ts/store/reducers/entities/services/index.ts
@@ -3,7 +3,7 @@
  */
 import { combineReducers } from "redux";
 
-import { Action } from "../../../../actions/types";
+import { Action } from "../../../actions/types";
 import servicesAllIdsReducer, { ServicesAllIdsState } from "./servicesAllIds";
 
 import servicesByIdReducer, { ServicesByIdState } from "./servicesById";

--- a/ts/store/reducers/entities/services/servicesAllIds.ts
+++ b/ts/store/reducers/entities/services/servicesAllIds.ts
@@ -4,8 +4,8 @@
  * are managed by different global reducers.
  */
 
-import { Action } from "../../../../actions/types";
 import { SERVICE_LOAD_SUCCESS } from "../../../actions/constants";
+import { Action } from "../../../actions/types";
 
 // An array of services id
 export type ServicesAllIdsState = ReadonlyArray<string>;

--- a/ts/store/reducers/entities/services/servicesById.ts
+++ b/ts/store/reducers/entities/services/servicesById.ts
@@ -5,9 +5,9 @@
  */
 
 import { ServicePublic } from "../../../../../definitions/backend/ServicePublic";
-import { Action } from "../../../../actions/types";
 import { GlobalState } from "../../../../reducers/types";
 import { SERVICE_LOAD_SUCCESS } from "../../../actions/constants";
+import { Action } from "../../../actions/types";
 
 export type ServicesByIdState = Readonly<{
   [key: string]: ServicePublic;

--- a/ts/store/reducers/error.ts
+++ b/ts/store/reducers/error.ts
@@ -6,9 +6,9 @@
  */
 
 import { isSome, none, Option } from "fp-ts/lib/Option";
-import { Action } from "../../actions/types";
 import { GlobalState } from "../../reducers/types";
 import { ERROR_CLEAR, FetchRequestActionsType } from "../actions/constants";
+import { Action } from "../actions/types";
 
 export type ErrorState = Readonly<
   { [key in FetchRequestActionsType]: Option<string> }

--- a/ts/store/reducers/loading.ts
+++ b/ts/store/reducers/loading.ts
@@ -4,9 +4,9 @@
  *
  * - ACTION_NAME_(REQUEST|CANCEL|SUCCESS|FAILURE)
  */
-import { Action } from "../../actions/types";
 import { GlobalState } from "../../reducers/types";
 import { FetchRequestActionsType } from "../actions/constants";
+import { Action } from "../actions/types";
 
 export type LoadingState = Readonly<
   { [key in FetchRequestActionsType]: boolean }

--- a/ts/store/reducers/notifications/index.ts
+++ b/ts/store/reducers/notifications/index.ts
@@ -3,7 +3,7 @@
  */
 
 import { combineReducers } from "redux";
-import { Action } from "../../../actions/types";
+import { Action } from "../../actions/types";
 import installationReducer, { InstallationState } from "./installation";
 
 export type NotificationsState = {

--- a/ts/store/reducers/notifications/installation.ts
+++ b/ts/store/reducers/notifications/installation.ts
@@ -4,9 +4,9 @@
 
 import uuid from "uuid/v4";
 
-import { Action } from "../../../actions/types";
 import { GlobalState } from "../../../reducers/types";
 import { NOTIFICATIONS_INSTALLATION_TOKEN_UPDATE } from "../../actions/constants";
+import { Action } from "../../actions/types";
 
 export type InstallationState = Readonly<{
   uuid: string;

--- a/ts/store/reducers/onboarding.ts
+++ b/ts/store/reducers/onboarding.ts
@@ -3,9 +3,9 @@
  * @flow
  */
 
-import { Action } from "../../actions/types";
 import { GlobalState } from "../../reducers/types";
 import { PIN_CREATE_SUCCESS, TOS_ACCEPT_SUCCESS } from "../actions/constants";
+import { Action } from "../actions/types";
 
 export type OnboardingState = Readonly<{
   isTosAccepted: boolean;

--- a/ts/store/reducers/profile.ts
+++ b/ts/store/reducers/profile.ts
@@ -7,12 +7,12 @@
  * @flow
  */
 
-import { Action } from "../../actions/types";
 import { ApiProfile } from "../../api";
 import {
   PROFILE_LOAD_SUCCESS,
   PROFILE_UPDATE_SUCCESS
 } from "../actions/constants";
+import { Action } from "../actions/types";
 
 export type ProfileState = ApiProfile | null;
 

--- a/ts/store/reducers/session.ts
+++ b/ts/store/reducers/session.ts
@@ -2,11 +2,11 @@
  * A reducer for the Session.
  */
 
-import { Action } from "../../actions/types";
 import { IdentityProvider } from "../../models/IdentityProvider";
 import { GlobalState } from "../../reducers/types";
 import { SessionToken } from "../../types/SessionToken";
 import { IDP_SELECTED, LOGIN_SUCCESS } from "../actions/constants";
+import { Action } from "../actions/types";
 
 export type UnauthenticatedWithoutIdpSessionState = Readonly<{
   isAuthenticated: false;


### PR DESCRIPTION
Action types are still in the old `/ts/actions` directory. This PR move this file in `/ts/store/actions` where all the other actions related files are.

All changes are to fix the related imports.