### PR TITLE
Fix appState reducer directory

### DIFF
--- a/ts/store/reducers/__tests__/appState.test.ts
+++ b/ts/store/reducers/__tests__/appState.test.ts
@@ -1,6 +1,6 @@
-import appState, { initialAppState } from "../../../sore/reducers/appState";
 import { APP_STATE_CHANGE_ACTION } from "../../actions/constants";
 import { ApplicationStateAction } from "../../actions/types";
+import appState, { initialAppState } from "../appState";
 
 describe("appState reducer", () => {
   it("should have a valid initial state", () => {

--- a/ts/store/reducers/appState.ts
+++ b/ts/store/reducers/appState.ts
@@ -4,8 +4,8 @@
  * Handles React Native's AppState changes.
  */
 
-import { APP_STATE_CHANGE_ACTION } from "../../store/actions/constants";
-import { Action, ApplicationState } from "../../store/actions/types";
+import { APP_STATE_CHANGE_ACTION } from "../actions/constants";
+import { Action, ApplicationState } from "../actions/types";
 
 export type AppState = Readonly<{
   appState: ApplicationState;

--- a/ts/store/reducers/index.ts
+++ b/ts/store/reducers/index.ts
@@ -6,8 +6,8 @@ import { reducer as networkReducer } from "react-native-offline";
 import { Reducer, ReducersMapObject } from "redux";
 import { FormStateMap, reducer as formReducer } from "redux-form";
 
-import appStateReducer from "../../sore/reducers/appState";
 import { Action } from "../actions/types";
+import appStateReducer from "./appState";
 import entitiesReducer from "./entities";
 import errorReducer from "./error";
 import loadingReducer from "./loading";

--- a/ts/store/reducers/types.ts
+++ b/ts/store/reducers/types.ts
@@ -1,8 +1,8 @@
 import { NavigationState } from "react-navigation";
 import { FormStateMap } from "redux-form";
 
-import { AppState } from "../../sore/reducers/appState";
 import { Action } from "../actions/types";
+import { AppState } from "./appState";
 import { EntitiesState } from "./entities";
 import { ErrorState } from "./error";
 import { LoadingState } from "./loading";


### PR DESCRIPTION
During refactoring the appState reducer was moved to 'sore' instead of 'store'.