### PR TITLE
fixing minor bug in the transaction details screen

### DIFF
--- a/ts/components/wallet/TransactionsList.tsx
+++ b/ts/components/wallet/TransactionsList.tsx
@@ -21,6 +21,7 @@ import { connect, Dispatch } from "react-redux";
 import I18n from "../../i18n";
 import ROUTES from "../../navigation/routes";
 
+import { selectCardForDetails } from "../../store/actions/wallet/cards";
 import { selectTransactionForDetails } from "../../store/actions/wallet/transactions";
 import { GlobalState } from "../../store/reducers/types";
 import {
@@ -36,6 +37,7 @@ type ReduxMappedStateProps = Readonly<{
 
 type ReduxMappedDispatchProps = Readonly<{
   selectTransaction: (i: WalletTransaction) => void;
+  selectCard: (item: number) => void;
 }>;
 
 /**
@@ -85,6 +87,7 @@ class TransactionsList extends React.Component<Props> {
     <ListItem
       onPress={() => {
         this.props.selectTransaction(item);
+        this.props.selectCard(item.cardId);
         this.props.navigation.navigate(ROUTES.WALLET_TRANSACTION_DETAILS);
       }}
     >
@@ -167,7 +170,8 @@ const mapStateToProps = (
 };
 
 const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedDispatchProps => ({
-  selectTransaction: item => dispatch(selectTransactionForDetails(item))
+  selectTransaction: item => dispatch(selectTransactionForDetails(item)),
+  selectCard: item => dispatch(selectCardForDetails(item))
 });
 
 export default connect(

--- a/ts/store/actions/wallet/cards.ts
+++ b/ts/store/actions/wallet/cards.ts
@@ -16,7 +16,7 @@ export type CardsFetched = Readonly<{
 
 export type CardSelectedForDetails = Readonly<{
   type: typeof SELECT_CARD_FOR_DETAILS;
-  payload: CreditCard;
+  payload: CreditCard | number; // either a card or its id
 }>;
 
 export type CardsActions =
@@ -36,7 +36,7 @@ export const cardsFetched = (
 });
 
 export const selectCardForDetails = (
-  card: CreditCard
+  card: CreditCard | number
 ): CardSelectedForDetails => ({
   type: SELECT_CARD_FOR_DETAILS,
   payload: card

--- a/ts/store/reducers/wallet/cards.ts
+++ b/ts/store/reducers/wallet/cards.ts
@@ -63,7 +63,9 @@ const reducer = (
   if (action.type === SELECT_CARD_FOR_DETAILS) {
     return {
       ...state,
-      selectedCardId: some(action.payload.id)
+      selectedCardId: some(
+        typeof action.payload === "number" ? action.payload : action.payload.id
+      )
     };
   }
   return state;


### PR DESCRIPTION
The `selectedCardId` property of the wallet state (used to update the card preview at the top of the layout) was not being set when accessing the "transaction details" screen directly from a transactions list (and not from the "transactions by card" screen). 

This PR fixes it, by setting the selected card id value directly when selecting a transaction. 