### PR TITLE
reordering components

### DIFF
--- a/ts/components/wallet/PaymentMethodsList.tsx
+++ b/ts/components/wallet/PaymentMethodsList.tsx
@@ -11,10 +11,10 @@ import * as React from "react";
 import { FlatList, StyleSheet } from "react-native";
 import { Grid, Row } from "react-native-easy-grid";
 import { NavigationScreenProp, NavigationState } from "react-navigation";
-import I18n from "../../../i18n";
-import ROUTES from "../../../navigation/routes";
-import Icon from "../../../theme/font-icons/io-icon-font/index";
-import variables from "../../../theme/variables";
+import I18n from "../../i18n";
+import ROUTES from "../../navigation/routes";
+import Icon from "../../theme/font-icons/io-icon-font/index";
+import variables from "../../theme/variables";
 
 type Props = Readonly<{
   navigation: NavigationScreenProp<NavigationState>;
@@ -71,10 +71,7 @@ const AddMethodStyle = StyleSheet.create({
   }
 });
 
-export default class AddNewPaymentMethodComponent extends React.Component<
-  Props,
-  never
-> {
+export default class PaymentMethodsList extends React.Component<Props, never> {
   public render(): React.ReactNode {
     const { navigate } = this.props.navigation;
 

--- a/ts/screens/wallet/AddPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/AddPaymentMethodScreen.tsx
@@ -28,7 +28,7 @@ import { WalletStyles } from "../../components/styles/wallet";
 import AppHeader from "../../components/ui/AppHeader";
 import IconFont from "../../components/ui/IconFont";
 import PaymentBannerComponent from "../../components/wallet/PaymentBannerComponent";
-import AddNewPaymentMethodComponent from "../../components/wallet/payWith/addNewPaymentMethodComponent";
+import PaymentMethodsList from "../../components/wallet/PaymentMethodsList";
 import I18n from "../../i18n";
 import variables from "../../theme/variables";
 import { TransactionSummary } from "../../types/wallet";
@@ -53,7 +53,7 @@ export class AddPaymentMethodScreen extends React.Component<Props, never> {
    *    https://www.pivotaltracker.com/n/projects/2048617/stories/158395136
    */
   private isInTransaction() {
-    return true;
+    return false;
   }
 
   public render(): React.ReactNode {
@@ -70,30 +70,34 @@ export class AddPaymentMethodScreen extends React.Component<Props, never> {
           </Left>
           <Body>
             {this.isInTransaction() ? (
-              <Text> {I18n.t("wallet.payWith.header")} </Text>
+              <Text>{I18n.t("wallet.payWith.header")}</Text>
             ) : (
-              <Text> {I18n.t("wallet.addPaymentMethodTitle")} </Text>
+              <Text>{I18n.t("wallet.addPaymentMethodTitle")}</Text>
             )}
           </Body>
         </AppHeader>
-        <Content noPadded={true}>
-          {this.isInTransaction() && (
+        {this.isInTransaction() ? (
+          <Content noPadded={true}>
             <PaymentBannerComponent
               navigation={this.props.navigation}
               paymentReason={transaction.paymentReason}
               currentAmount={transaction.totalAmount.toString()}
               entity={transaction.entityName}
             />
-          )}
-          <View style={WalletStyles.paddedLR}>
-            <View spacer={true} large={true} />
-            {this.isInTransaction() && (
-              <H1> {I18n.t("wallet.payWith.title")} </H1>
-            )}
-            <View spacer={true} />
-            <AddNewPaymentMethodComponent navigation={this.props.navigation} />
-          </View>
-        </Content>
+            <View style={WalletStyles.paddedLR}>
+              <View spacer={true} large={true} />
+              {this.isInTransaction() && (
+                <H1>{I18n.t("wallet.payWith.title")}</H1>
+              )}
+              <View spacer={true} />
+              <PaymentMethodsList navigation={this.props.navigation} />
+            </View>
+          </Content>
+        ) : (
+          <Content>
+            <PaymentMethodsList navigation={this.props.navigation} />
+          </Content>
+        )}
         <View footer={true}>
           <Button
             block={true}


### PR DESCRIPTION
This PR fixes some open points about previous PRs. 

In particular, it fixes the "payment banner" prepended to the "add payment method" screen. 

In the long term, it is probably worth considering whether a "withPaymentBanner" HOC should be introduced to create screens that (1) display the relevant banner and (2) are aligned with the original screens. 

Additionally, since things are getting crowded in screens/wallet, the files may be organized in subdirectories:
```
screen/
  wallet/
    payment/
      ... files for handling payments ...
    newMethod/
      ... files to add a new payment method ...
    ... files for managing the wallet ...
```