### PR TITLE
[#158451703] Add the Android release build to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,8 +182,8 @@ jobs:
           command: cd android && bundle exec fastlane release_build
 
       - store_artifacts:
-          path: android/app/build/outputs/apk/app-release.apk
-          destination: apks/
+          path: android/app/build/outputs/apk
+          destination: apks/release
 
   # Test ios build
   test-ios:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,8 +126,8 @@ jobs:
             - ~/.gradle
           key: jars-{{ checksum "android/build.gradle" }}-{{ checksum  "android/app/build.gradle" }}
 
-  # Create signed Android release
-  release-android:
+  # Create signed Android release and deploy a new alpha version to the Google Play Store
+  alpha-release-android:
     <<: *defaults
 
     docker:
@@ -177,9 +177,9 @@ jobs:
       # Build the js bundle in release mode
       - run: yarn bundle:android-release
 
-      # Run release_build lane
+      # Run alpha lane
       - run:
-          command: cd android && bundle exec fastlane release_build
+          command: cd android && bundle exec fastlane alpha
 
       - store_artifacts:
           path: android/app/build/outputs/apk
@@ -272,7 +272,7 @@ workflows:
             - hold-native-tests
 
       # Build Android release only on tags
-      - release-android:
+      - alpha-release-android:
           requires:
             - test-android
          # Disabled to check the build is ok   

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,49 @@ jobs:
             - ~/.gradle
           key: jars-{{ checksum "android/build.gradle" }}-{{ checksum  "android/app/build.gradle" }}
 
+  # Create signed Android release
+  release-android:
+    <<: *defaults
+
+    docker:
+      - image: circleci/android:api-27-node8-alpha
+
+    environment:
+      - TERM: "dumb"
+      - ANDROID_SDK_BUILD_TOOLS_REVISION: "23.0.1"
+      - ANDROID_SDK_BUILD_API_LEVEL="23": "23"
+
+    steps:
+      # Restore workflow workspace
+      - attach_workspace:
+          at: /home/circleci
+
+      # Restore sdk cache
+      - restore_cache:
+          keys:
+            - v1-android-sdkmanager-packages-{{ checksum "scripts/circleci-android-setup.sh" }}
+            - v1-android-sdkmanager-packages-
+
+      # Install Android SDK
+      - run:
+          command: ./scripts/circleci-android-setup.sh
+
+      # Restore jars cache
+      - restore_cache:
+          key: jars-{{ checksum "android/build.gradle" }}-{{ checksum  "android/app/build.gradle" }}
+
+      # Recreate keystore from ENV variable
+      - run:
+          command: ./scripts/keystore-setup.sh
+
+      # Run release_build lane
+      - run:
+          command: cd android && bundle exec fastlane release_build
+
+      - store_artifacts:
+          path: android/app/build/outputs/apk/app-release.apk
+          destination: apks/
+
   # Test ios build
   test-ios:
     <<: *defaults
@@ -212,3 +255,13 @@ workflows:
           requires:
             - hold-native-tests
 
+      # Build Android release oly on tags
+      - release-android:
+          requires:
+            - test-android
+         # Disabled to check the build is ok   
+         # filters:
+         #   branches:
+         #     ignore: /.*/
+         #   tags:
+         #     only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,13 +271,10 @@ workflows:
           requires:
             - hold-native-tests
 
-      # Build Android release only on tags
+      # Build Android alpha release only on master branch
       - alpha-release-android:
           requires:
-            - test-android
-         # Disabled to check the build is ok   
-         # filters:
-         #   branches:
-         #     ignore: /.*/
-         #   tags:
-         #     only: /^v.*/
+            - test-js-node-8
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,17 @@ jobs:
       - restore_cache:
           key: jars-{{ checksum "android/build.gradle" }}-{{ checksum  "android/app/build.gradle" }}
 
+      # Set Ruby Version for chruby
+      - run: echo "ruby-2.4" > .ruby-version
+
+      # Install bundle dependencies
+      - run:
+          name: Bundle Install
+          command: bundle check || bundle install
+
+      # Fetch CocoaPods specs
+      - run: curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
+
       # Recreate keystore from ENV variable
       - run:
           command: ./scripts/keystore-setup.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,7 @@ jobs:
       - TERM: "dumb"
       - ANDROID_SDK_BUILD_TOOLS_REVISION: "23.0.1"
       - ANDROID_SDK_BUILD_API_LEVEL="23": "23"
+      - REACT_NATIVE_MAX_WORKERS: 1
 
     steps:
       # Restore workflow workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,8 +175,7 @@ jobs:
           command: ./scripts/keystore-setup.sh
 
       # Build the js bundle in release mode
-      - run:
-          command: react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res/
+      - run: yarn bundle:android-release
 
       # Run release_build lane
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,10 @@ jobs:
       - run:
           command: ./scripts/keystore-setup.sh
 
+      # Build the js bundle in release mode
+      - run:
+          command: react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res/
+
       # Run release_build lane
       - run:
           command: cd android && bundle exec fastlane release_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,8 +165,9 @@ jobs:
           name: Bundle Install
           command: bundle check || bundle install
 
-      # Fetch CocoaPods specs
-      - run: curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
+      # Recreate JSON key file (for Google Play) from ENV variable
+      - run:
+          command: ./scripts/json-key-file-setup.sh
 
       # Recreate keystore from ENV variable
       - run:
@@ -266,7 +267,7 @@ workflows:
           requires:
             - hold-native-tests
 
-      # Build Android release oly on tags
+      # Build Android release only on tags
       - release-android:
           requires:
             - test-android

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -109,7 +109,7 @@ android {
         applicationId "it.teamdigitale.app.italiaapp"
         minSdkVersion 16
         targetSdkVersion 22
-        versionCode 4
+        versionCode 5
         versionName "1.0"
         ndk {
             abiFilters "armeabi-v7a", "x86"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -109,8 +109,8 @@ android {
         applicationId "it.teamdigitale.app.italiaapp"
         minSdkVersion 16
         targetSdkVersion 22
-        versionCode 6
-        versionName "1.0"
+        versionCode System.getenv('CIRCLE_BUILD_NUM').toInteger()
+        versionName "1.0." + System.getenv('CIRCLE_BUILD_NUM')
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -109,7 +109,7 @@ android {
         applicationId "it.teamdigitale.app.italiaapp"
         minSdkVersion 16
         targetSdkVersion 22
-        versionCode 5
+        versionCode 6
         versionName "1.0"
         ndk {
             abiFilters "armeabi-v7a", "x86"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -117,11 +117,11 @@ android {
     }
     signingConfigs {
         release {
-            if (project.hasProperty('MYAPP_RELEASE_STORE_FILE')) {
-                storeFile file(MYAPP_RELEASE_STORE_FILE)
-                storePassword MYAPP_RELEASE_STORE_PASSWORD
-                keyAlias MYAPP_RELEASE_KEY_ALIAS
-                keyPassword MYAPP_RELEASE_KEY_PASSWORD
+            if (System.getenv('ITALIAAPP_RELEASE_STORE_FILE')) {
+                storeFile file(System.getenv('ITALIAAPP_RELEASE_STORE_FILE'))
+                storePassword System.getenv('ITALIAAPP_RELEASE_STORE_PASSWORD')
+                keyAlias System.getenv('ITALIAAPP_RELEASE_KEY_ALIAS')
+                keyPassword System.getenv('ITALIAAPP_RELEASE_KEY_PASSWORD')
             }
         }
     }

--- a/android/fastlane/Appfile
+++ b/android/fastlane/Appfile
@@ -1,2 +1,2 @@
-json_key_file "./app/Google Play Android Developer-04750d2c0cf8.json" # Path to the json secret file - Follow https://github.com/fastlane/supply#setup to get one
+json_key_file "/tmp/json-key.json" # Path to the json secret file - Follow https://github.com/fastlane/supply#setup to get one
 package_name "it.teamdigitale.app.italiaapp" # e.g. com.krausefx.app

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -36,7 +36,7 @@ platform :android do
   desc "Build the app in release mode and deploy a new alpha version to the Google Play Store"
   lane :alpha do
     # Ensure that your git status is not dirty
-    ensure_git_status_clean
+    # ensure_git_status_clean
     
     gradle(
       task: "assemble",

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -38,6 +38,7 @@ platform :android do
     gradle(
       task: 'assemble',
       build_type: 'Release'
+      flags: '--no-daemon'
     )
   end
 

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -33,6 +33,14 @@ platform :android do
     )
   end
 
+  desc "Build the app in release mode"
+  lane :release_build do
+    gradle(
+      task: 'assemble',
+      build_type: 'Release'
+    )
+  end
+
   desc "Deploy a new alpha version to the Google Play Store"
   lane :alpha do
     # Ensure that your git status is not dirty

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -37,7 +37,7 @@ platform :android do
   lane :release_build do
     gradle(
       task: 'assemble',
-      build_type: 'Release'
+      build_type: 'Release',
       flags: '--no-daemon'
     )
   end

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -28,34 +28,26 @@ platform :android do
   desc "Build the app in debug mode"
   lane :test_build do
     gradle(
-      task: 'assemble',
-      build_type: 'Debug'
+      task: "assemble",
+      build_type: "Debug"
     )
   end
 
-  desc "Build the app in release mode"
-  lane :release_build do
-    gradle(
-      task: 'assemble',
-      build_type: 'Release',
-      flags: '-x bundleReleaseJsAndAssets --no-daemon'
-    )
-  end
-
-  desc "Deploy a new alpha version to the Google Play Store"
+  desc "Build the app in release mode and deploy a new alpha version to the Google Play Store"
   lane :alpha do
     # Ensure that your git status is not dirty
     ensure_git_status_clean
     
     gradle(
       task: "assemble",
-      build_type: "Release"
+      build_type: "Release",
+      flags: "-x bundleReleaseJsAndAssets --no-daemon"
     )
 
     # Generate the changelog based on commit messages since your last tag
     changelog_from_git_commits
 
-    supply(
+    upload_to_play_store(
       track: "alpha",
       apk: "#{lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH]}"
     )

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -38,7 +38,7 @@ platform :android do
     gradle(
       task: 'assemble',
       build_type: 'Release',
-      flags: '--no-daemon'
+      flags: '-x bundleReleaseJsAndAssets --no-daemon'
     )
   end
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "tsc:noemit": "tsc --noemit",
     "lint": "tslint -p . -c tslint.json -t verbose",
     "lint-autofix": "tslint -p . -c tslint.json -t verbose --fix",
-    "generate:api-definitions": "rimraf definitions/backend && mkdir -p definitions/backend && gen-api-models --api-spec https://raw.githubusercontent.com/teamdigitale/italia-backend/v0.0.22/api_proxy.yaml --out-dir ./definitions/backend"
+    "generate:api-definitions": "rimraf definitions/backend && mkdir -p definitions/backend && gen-api-models --api-spec https://raw.githubusercontent.com/teamdigitale/italia-backend/v0.0.22/api_proxy.yaml --out-dir ./definitions/backend",
+    "bundle:android-release": "node node_modules/react-native/local-cli/cli.js bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res/"
   },
   "dependencies": {
     "color": "^3.0.0",

--- a/scripts/json-key-file-setup.sh
+++ b/scripts/json-key-file-setup.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo $ENCODED_ITALIAAPP_JSON_KEY_FILE | base64 --decode >> /tmp/json-key.json
+echo $ENCODED_ITALIAAPP_JSON_KEY_FILE | base64 --decode > /tmp/json-key.json

--- a/scripts/json-key-file-setup.sh
+++ b/scripts/json-key-file-setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo $ENCODED_ITALIAAPP_JSON_KEY_FILE | base64 --decode >> /tmp/json-key.json

--- a/scripts/keystore-setup.sh
+++ b/scripts/keystore-setup.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo $ENCODED_ITALIAAPP_RELEASE_KEYSTORE | base64 --decode >> ${HOME}/italia-app/android/app/italiaapp-release.keystore
+echo $ENCODED_ITALIAAPP_RELEASE_KEYSTORE | base64 --decode >> /tmp/italiaapp-release.keystore

--- a/scripts/keystore-setup.sh
+++ b/scripts/keystore-setup.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo $ENCODED_ITALIAAPP_RELEASE_KEYSTORE | base64 --decode >> /tmp/italiaapp-release.keystore
+echo $ENCODED_ITALIAAPP_RELEASE_KEYSTORE | base64 --decode > /tmp/italiaapp-release.keystore

--- a/scripts/keystore-setup.sh
+++ b/scripts/keystore-setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo $ENCODED_ITALIAAPP_RELEASE_KEYSTORE | base64 --decode >> ${HOME}/italia-app/android/app/italiaapp-release.keystore


### PR DESCRIPTION
To make this works:

**Create/dowload the json key file**

Follow this [guide](https://docs.fastlane.tools/getting-started/android/setup/)

**Create the base64 representation using**

```
cat youfile.json | base64
```

**Create a keystore using:**

```
$ keytool -genkey -v -keystore italiaapp-release.keystore -alias italiaapp-release -keyalg RSA -keysize 2048 -validity 10000
```

this command prompts you for passwords for the keystore and key, and to provide the Distinguished Name fields for your key.

**Create the base64 representation using**

```
cat italiaapp-release.keystore | base64
```

**In CircleCI add the following env valiables**

```
ENCODED_ITALIAAPP_JSON_KEY_FILE=[INSERT THE BASE64 REPRESENTATION OF THE GOOGLE PLAY JSON KEY FILE]
ENCODED_ITALIAAPP_RELEASE_KEYSTORE=[INSERT THE BASE64 REPRESENTATION OF THE KEYSTORE]
ITALIAAPP_RELEASE_STORE_FILE=/tmp/italiaapp-release.keystore
ITALIAAPP_RELEASE_KEY_ALIAS=italiaapp-release
ITALIAAPP_RELEASE_STORE_PASSWORD=[INSERT STORE PASSWORD HERE]
ITALIAAPP_RELEASE_KEY_PASSWORD=[INSERT KEY PASSWORD HERE]
```