### PR TITLE
Types react redux 5.0.20 fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@types/react-native-push-notification": "^3.0.2",
     "@types/react-native-vector-icons": "^4.6.1",
     "@types/react-navigation": "^1.5.10",
-    "@types/react-redux": "^5.0.18",
+    "@types/react-redux": "^5.0.20",
     "@types/react-test-renderer": "^16.0.1",
     "@types/redux-form": "^7.2.6",
     "@types/redux-logger": "^3.0.6",

--- a/ts/components/wallet/PaymentBannerComponent.tsx
+++ b/ts/components/wallet/PaymentBannerComponent.tsx
@@ -8,16 +8,17 @@
 import { Text, View } from "native-base";
 import * as React from "react";
 import { Col, Grid, Row } from "react-native-easy-grid";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 import I18n from "../../i18n";
 import { WalletStyles } from "../styles/wallet";
 
-type Props = Readonly<{
-  navigation: NavigationScreenProp<NavigationState>;
+type OwnProps = Readonly<{
   paymentReason: string;
   currentAmount: string;
   entity: string;
 }>;
+
+type Props = OwnProps & NavigationScreenProps<NavigationState>;
 
 export default class PaymentBannerComponent extends React.Component<Props> {
   public render(): React.ReactNode {

--- a/ts/components/wallet/PaymentMethodsList.tsx
+++ b/ts/components/wallet/PaymentMethodsList.tsx
@@ -10,15 +10,13 @@ import { Left, ListItem, Right, Text, View } from "native-base";
 import * as React from "react";
 import { FlatList, StyleSheet } from "react-native";
 import { Grid, Row } from "react-native-easy-grid";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 import I18n from "../../i18n";
 import ROUTES from "../../navigation/routes";
 import Icon from "../../theme/font-icons/io-icon-font/index";
 import variables from "../../theme/variables";
 
-type Props = Readonly<{
-  navigation: NavigationScreenProp<NavigationState>;
-}>;
+type Props = NavigationScreenProps<NavigationState>;
 
 type Route = keyof typeof ROUTES;
 

--- a/ts/components/wallet/PaymentSummaryComponent.tsx
+++ b/ts/components/wallet/PaymentSummaryComponent.tsx
@@ -5,16 +5,17 @@ import { H1, H3, Icon, Right, Text, View } from "native-base";
 import * as React from "react";
 import { StyleSheet } from "react-native";
 import { Grid, Row } from "react-native-easy-grid";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 import { WalletStyles } from "../../components/styles/wallet";
 import I18n from "../../i18n";
 import variables from "../../theme/variables";
 
-type Props = Readonly<{
-  navigation: NavigationScreenProp<NavigationState>;
+type OwnProps = Readonly<{
   amount: string;
   updatedAmount: string;
 }>;
+
+type Props = OwnProps & NavigationScreenProps<NavigationState>;
 
 const styles = StyleSheet.create({
   padded: {

--- a/ts/components/wallet/TransactionsList.tsx
+++ b/ts/components/wallet/TransactionsList.tsx
@@ -165,7 +165,9 @@ const mapStateToProps = (
   return { transactions: [] };
 };
 
-const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedDispatchProps => ({
+const mapDispatchToProps = (
+  dispatch: Dispatch<GlobalState>
+): ReduxMappedDispatchProps => ({
   selectTransaction: item => dispatch(selectTransactionForDetails(item)),
   selectCard: item => dispatch(selectCardForDetails(item))
 });

--- a/ts/components/wallet/TransactionsList.tsx
+++ b/ts/components/wallet/TransactionsList.tsx
@@ -13,7 +13,7 @@ import {
   Text
 } from "native-base";
 import * as React from "react";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 
 import { Content } from "native-base";
 import { connect, Dispatch } from "react-redux";
@@ -52,11 +52,14 @@ export enum TransactionsDisplayed {
 type OwnProps = Readonly<{
   title: string;
   totalAmount: string;
-  navigation: NavigationScreenProp<NavigationState>;
   display: TransactionsDisplayed;
 }>;
 
-type Props = OwnProps & ReduxMappedStateProps & ReduxMappedDispatchProps;
+type Props = OwnProps &
+  ReduxMappedStateProps &
+  ReduxMappedDispatchProps &
+  NavigationScreenProps<NavigationState>;
+
 /**
  * Transactions List component
  */

--- a/ts/components/wallet/WalletLayout.tsx
+++ b/ts/components/wallet/WalletLayout.tsx
@@ -8,12 +8,12 @@
  * footer with a button for starting a new payment
  */
 import { Body, Container, Content, Text, View } from "native-base";
-import { Left } from "native-base";
 import { Button } from "native-base";
+import { Left } from "native-base";
 import * as React from "react";
 import { ScrollView } from "react-native";
 import { Image, StyleSheet, TouchableHighlight } from "react-native";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 import IconFont from "../../components/ui/IconFont";
 import I18n from "../../i18n";
 import ROUTES from "../../navigation/routes";
@@ -63,14 +63,15 @@ type NoCards = Readonly<{
 
 export type CardType = FullCard | HeaderCard | FannedCards | NoCards;
 
-type Props = Readonly<{
+type OwnProps = Readonly<{
   title: string;
-  navigation: NavigationScreenProp<NavigationState>;
   headerContents?: React.ReactNode;
   cardType?: CardType;
   showPayButton?: boolean;
   allowGoBack?: boolean;
 }>;
+
+type Props = OwnProps & NavigationScreenProps<NavigationState>;
 
 export class WalletLayout extends React.Component<Props> {
   public static defaultProps = {

--- a/ts/components/wallet/card/CardBody.tsx
+++ b/ts/components/wallet/card/CardBody.tsx
@@ -7,6 +7,7 @@ import { Right, Text } from "native-base";
 import * as React from "react";
 import { StyleSheet } from "react-native";
 import { Col, Row } from "react-native-easy-grid";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 import { CardProps } from ".";
 import I18n from "../../../i18n";
 import variables from "../../../theme/variables";
@@ -24,7 +25,9 @@ const styles = StyleSheet.create({
   }
 });
 
-export default class CardBody extends React.Component<CardProps> {
+type Props = CardProps & NavigationScreenProps<NavigationState>;
+
+export default class CardBody extends React.Component<Props> {
   /**
    * Display the right-end part of the
    * card body. This will be the card

--- a/ts/components/wallet/card/FooterRow.tsx
+++ b/ts/components/wallet/card/FooterRow.tsx
@@ -8,7 +8,7 @@
 import { Text } from "native-base";
 import * as React from "react";
 import { Col, Row } from "react-native-easy-grid";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
 import ROUTES from "../../../navigation/routes";
 import { Dispatch } from "../../../store/actions/types";
@@ -23,12 +23,13 @@ type ReduxMappedProps = Readonly<{
 }>;
 
 type OwnProps = Readonly<{
-  navigation: NavigationScreenProp<NavigationState>;
   item: CreditCard;
   showMsg?: boolean;
 }>;
 
-type Props = OwnProps & ReduxMappedProps;
+type Props = OwnProps &
+  ReduxMappedProps &
+  NavigationScreenProps<NavigationState>;
 
 class FooterRow extends React.Component<Props> {
   public static defaultProps: Partial<Props> = {

--- a/ts/components/wallet/card/index.tsx
+++ b/ts/components/wallet/card/index.tsx
@@ -13,7 +13,7 @@ import {
   ViewStyle
 } from "react-native";
 import { Col, Grid, Row } from "react-native-easy-grid";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 
 import I18n from "../../../i18n";
 
@@ -85,7 +85,6 @@ type ReduxMappedDispatchProps = Readonly<{
 
 export type CardProps = Readonly<{
   item: CreditCard;
-  navigation: NavigationScreenProp<NavigationState>;
   menu?: boolean;
   favorite?: boolean;
   lastUsage?: boolean;
@@ -98,7 +97,10 @@ export type CardProps = Readonly<{
   customStyle?: any;
 }>;
 
-type Props = CardProps & ReduxMappedStateProps & ReduxMappedDispatchProps;
+type Props = CardProps &
+  ReduxMappedStateProps &
+  ReduxMappedDispatchProps &
+  NavigationScreenProps<NavigationState>;
 
 /**
  * Credit card component

--- a/ts/components/wallet/card/index.tsx
+++ b/ts/components/wallet/card/index.tsx
@@ -254,7 +254,9 @@ const mapStateToProps = (
   };
 };
 
-const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedDispatchProps => ({
+const mapDispatchToProps = (
+  dispatch: Dispatch<GlobalState>
+): ReduxMappedDispatchProps => ({
   setFavoriteCard: (item: Option<CreditCardId>) =>
     dispatch(setFavoriteCard(item))
 });

--- a/ts/navigation/AuthenticationNavigator.ts
+++ b/ts/navigation/AuthenticationNavigator.ts
@@ -4,6 +4,7 @@ import IdpLoginScreen from "../screens/authentication/IdpLoginScreen";
 import IdpSelectionScreen from "../screens/authentication/IdpSelectionScreen";
 import LandingScreen from "../screens/authentication/LandingScreen";
 import SpidInformationRequestScreen from "../screens/authentication/SpidInformationRequestScreen";
+import { SafeNavigationScreenComponent } from "../types/redux_navigation";
 import ROUTES from "./routes";
 
 /**
@@ -12,16 +13,24 @@ import ROUTES from "./routes";
 const navigator = StackNavigator(
   {
     [ROUTES.AUTHENTICATION_LANDING]: {
-      screen: LandingScreen
+      screen: LandingScreen as SafeNavigationScreenComponent<
+        typeof LandingScreen
+      >
     },
     [ROUTES.AUTHENTICATION_IDP_SELECTION]: {
-      screen: IdpSelectionScreen
+      screen: IdpSelectionScreen as SafeNavigationScreenComponent<
+        typeof IdpSelectionScreen
+      >
     },
     [ROUTES.AUTHENTICATION_IDP_LOGIN]: {
-      screen: IdpLoginScreen
+      screen: IdpLoginScreen as SafeNavigationScreenComponent<
+        typeof IdpLoginScreen
+      >
     },
     [ROUTES.AUTHENTICATION_SPID_INFORMATION_REQUEST]: {
-      screen: SpidInformationRequestScreen
+      screen: SpidInformationRequestScreen as SafeNavigationScreenComponent<
+        typeof SpidInformationRequestScreen
+      >
     }
   },
   {

--- a/ts/navigation/MessagesNavigator.ts
+++ b/ts/navigation/MessagesNavigator.ts
@@ -1,4 +1,9 @@
-import { NavigationRouteConfigMap, StackNavigator } from "react-navigation";
+import {
+  NavigationComponent,
+  NavigationRouteConfigMap,
+  StackNavigator,
+  NavigationScreenComponent
+} from "react-navigation";
 import { MessageDetailsScreen } from "../screens/messages/MessageDetailsScreen";
 import MessagesScreen from "../screens/messages/MessagesScreen";
 
@@ -14,8 +19,8 @@ import ROUTES from "./routes";
 // };
 
 const messagesNavigatorConfig: NavigationRouteConfigMap = {
-  "[ROUTES.MESSAGES_LIST]": {
-    getScreen: () => MessagesScreen
+  [ROUTES.MESSAGES_LIST]: {
+    screen: MessagesScreen
   }
 };
 

--- a/ts/navigation/MessagesNavigator.ts
+++ b/ts/navigation/MessagesNavigator.ts
@@ -1,26 +1,18 @@
-import {
-  NavigationComponent,
-  NavigationRouteConfigMap,
-  StackNavigator,
-  NavigationScreenComponent
-} from "react-navigation";
+import { NavigationRouteConfigMap, StackNavigator } from "react-navigation";
 import { MessageDetailsScreen } from "../screens/messages/MessageDetailsScreen";
 import MessagesScreen from "../screens/messages/MessagesScreen";
+import { SafeNavigationScreenComponent } from "../types/redux_navigation";
 
 import ROUTES from "./routes";
 
-// const messagesNavigatorConfig: NavigationRouteConfigMap = {
-//   [ROUTES.MESSAGES_LIST]: {
-//     screen: MessagesScreen
-//   },
-//   [ROUTES.MESSAGE_DETAILS]: {
-//     screen: MessageDetailsScreen
-//   }
-// };
-
 const messagesNavigatorConfig: NavigationRouteConfigMap = {
   [ROUTES.MESSAGES_LIST]: {
-    screen: MessagesScreen
+    screen: MessagesScreen as SafeNavigationScreenComponent<
+      typeof MessagesScreen
+    >
+  },
+  [ROUTES.MESSAGE_DETAILS]: {
+    screen: MessageDetailsScreen
   }
 };
 

--- a/ts/navigation/MessagesNavigator.ts
+++ b/ts/navigation/MessagesNavigator.ts
@@ -1,22 +1,27 @@
-import { StackNavigator } from "react-navigation";
+import { NavigationRouteConfigMap, StackNavigator } from "react-navigation";
 import { MessageDetailsScreen } from "../screens/messages/MessageDetailsScreen";
 import MessagesScreen from "../screens/messages/MessagesScreen";
 
 import ROUTES from "./routes";
 
-const MessagesNavigator = StackNavigator(
-  {
-    [ROUTES.MESSAGES_LIST]: {
-      screen: MessagesScreen
-    },
-    [ROUTES.MESSAGE_DETAILS]: {
-      screen: MessageDetailsScreen
-    }
-  },
-  {
-    // Let each screen handle the header and navigation
-    headerMode: "none"
+// const messagesNavigatorConfig: NavigationRouteConfigMap = {
+//   [ROUTES.MESSAGES_LIST]: {
+//     screen: MessagesScreen
+//   },
+//   [ROUTES.MESSAGE_DETAILS]: {
+//     screen: MessageDetailsScreen
+//   }
+// };
+
+const messagesNavigatorConfig: NavigationRouteConfigMap = {
+  "[ROUTES.MESSAGES_LIST]": {
+    getScreen: () => MessagesScreen
   }
-);
+};
+
+const MessagesNavigator = StackNavigator(messagesNavigatorConfig, {
+  // Let each screen handle the header and navigation
+  headerMode: "none"
+});
 
 export default MessagesNavigator;

--- a/ts/navigation/OnboardingNavigator.ts
+++ b/ts/navigation/OnboardingNavigator.ts
@@ -2,6 +2,7 @@ import { StackNavigator } from "react-navigation";
 
 import PinScreen from "../screens/onboarding/PinScreen";
 import TosScreen from "../screens/onboarding/TosScreen";
+import { SafeNavigationScreenComponent } from "../types/redux_navigation";
 import ROUTES from "./routes";
 
 /**
@@ -10,10 +11,10 @@ import ROUTES from "./routes";
 const navigator = StackNavigator(
   {
     [ROUTES.ONBOARDING_TOS]: {
-      screen: TosScreen
+      screen: TosScreen as SafeNavigationScreenComponent<typeof TosScreen>
     },
     [ROUTES.ONBOARDING_PIN]: {
-      screen: PinScreen
+      screen: PinScreen as SafeNavigationScreenComponent<typeof PinScreen>
     }
   },
   {

--- a/ts/navigation/PinNavigator.ts
+++ b/ts/navigation/PinNavigator.ts
@@ -1,6 +1,7 @@
 import { StackNavigator } from "react-navigation";
 
 import PinLoginScreen from "../screens/PinLoginScreen";
+import { SafeNavigationScreenComponent } from "../types/redux_navigation";
 import ROUTES from "./routes";
 
 /**
@@ -9,7 +10,9 @@ import ROUTES from "./routes";
 const navigator = StackNavigator(
   {
     [ROUTES.PIN_LOGIN]: {
-      screen: PinLoginScreen
+      screen: PinLoginScreen as SafeNavigationScreenComponent<
+        typeof PinLoginScreen
+      >
     }
   },
   {

--- a/ts/navigation/WalletNavigator.ts
+++ b/ts/navigation/WalletNavigator.ts
@@ -12,6 +12,7 @@ import { QRcodeAcquisitionByScannerScreen } from "../screens/wallet/QRcodeAcquis
 import TransactionDetailsScreen from "../screens/wallet/TransactionDetailsScreen";
 import TransactionsScreen from "../screens/wallet/TransactionsScreen";
 import WalletHomeScreen from "../screens/wallet/WalletHomeScreen";
+import { SafeNavigationScreenComponent } from "../types/redux_navigation";
 import ROUTES from "./routes";
 
 /**
@@ -21,43 +22,69 @@ import ROUTES from "./routes";
 const WalletNavigator = StackNavigator(
   {
     [ROUTES.WALLET_HOME]: {
-      screen: WalletHomeScreen
+      screen: WalletHomeScreen as SafeNavigationScreenComponent<
+        typeof WalletHomeScreen
+      >
     },
     [ROUTES.WALLET_CREDITCARDS]: {
-      screen: CreditCardsScreen
+      screen: CreditCardsScreen as SafeNavigationScreenComponent<
+        typeof CreditCardsScreen
+      >
     },
     [ROUTES.WALLET_ADD_PAYMENT_METHOD]: {
-      screen: AddPaymentMethodScreen
+      screen: AddPaymentMethodScreen as SafeNavigationScreenComponent<
+        typeof AddPaymentMethodScreen
+      >
     },
     [ROUTES.WALLET_TRANSACTION_DETAILS]: {
-      screen: TransactionDetailsScreen
+      screen: TransactionDetailsScreen as SafeNavigationScreenComponent<
+        typeof TransactionDetailsScreen
+      >
     },
     [ROUTES.WALLET_CARD_TRANSACTIONS]: {
-      screen: TransactionsScreen
+      screen: TransactionsScreen as SafeNavigationScreenComponent<
+        typeof TransactionsScreen
+      >
     },
     [ROUTES.WALLET_ADD_CARD]: {
-      screen: AddCardScreen
+      screen: AddCardScreen as SafeNavigationScreenComponent<
+        typeof AddCardScreen
+      >
     },
     [ROUTES.WALLET_QRCODE_ACQUISITION_BY_SCANNER]: {
-      screen: QRcodeAcquisitionByScannerScreen
+      screen: QRcodeAcquisitionByScannerScreen as SafeNavigationScreenComponent<
+        typeof QRcodeAcquisitionByScannerScreen
+      >
     },
     [ROUTES.WALLET_ADD_MANAGER]: {
-      screen: AddManagerToCardScreen
+      screen: AddManagerToCardScreen as SafeNavigationScreenComponent<
+        typeof AddManagerToCardScreen
+      >
     },
     [ROUTES.WALLET_CONFIRM_TO_PROCEED]: {
-      screen: ConfirmToProceedTransactionScreen
+      screen: ConfirmToProceedTransactionScreen as SafeNavigationScreenComponent<
+        typeof ConfirmToProceedTransactionScreen
+      >
     },
     [ROUTES.WALLET_PAY_WITH]: {
-      screen: ChoosePaymentMethodScreen
+      screen: ChoosePaymentMethodScreen as SafeNavigationScreenComponent<
+        typeof ChoosePaymentMethodScreen
+      >
     },
     [ROUTES.WALLET_FIRST_TRANSACTION_SUMMARY]: {
-      screen: FirstTransactionSummaryScreen
+      screen: FirstTransactionSummaryScreen as SafeNavigationScreenComponent<
+        typeof FirstTransactionSummaryScreen
+      >
     },
     [ROUTES.WALLET_MANUAL_TRANSACTION_IDENTIFICATION]: {
-      screen: ManuallyIdentifyTransactionScreen
+      screen: ManuallyIdentifyTransactionScreen as SafeNavigationScreenComponent<
+        typeof ManuallyIdentifyTransactionScreen
+      >
     },
     [ROUTES.WALLET_ASK_SAVE_CARD]: {
-      screen: ConfirmSaveCardScreen
+      screen: ConfirmSaveCardScreen as SafeNavigationScreenComponent<
+        typeof ConfirmSaveCardScreen
+      >
     }
   },
   {

--- a/ts/screens/PinLoginScreen.tsx
+++ b/ts/screens/PinLoginScreen.tsx
@@ -1,7 +1,7 @@
 import { Button, Container, Content, Text, View } from "native-base";
 import * as React from "react";
 import CodeInput from "react-native-confirmation-code-input";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
 import Pinpad from "../components/Pinpad";
 import IconFont from "../components/ui/IconFont";
@@ -16,9 +16,7 @@ import variables from "../theme/variables";
 type ReduxMappedProps = {
   pinLoginState: PinLoginState;
 };
-type OwnProps = {
-  navigation: NavigationScreenProp<NavigationState>;
-};
+type OwnProps = NavigationScreenProps<NavigationState>;
 
 type Props = ReduxMappedProps & ReduxProps & OwnProps;
 

--- a/ts/screens/authentication/IdpLoginScreen.tsx
+++ b/ts/screens/authentication/IdpLoginScreen.tsx
@@ -1,7 +1,7 @@
 import { Body, Button, Container, Left, Text } from "native-base";
 import * as React from "react";
 import { NavState, WebView } from "react-native";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
 
 import AppHeader from "../../components/ui/AppHeader";
@@ -20,9 +20,7 @@ import { extractLoginResult } from "../../utils/login";
 type ReduxMappedProps = {
   authentication: AuthenticationState;
 };
-type OwnProps = {
-  navigation: NavigationScreenProp<NavigationState>;
-};
+type OwnProps = NavigationScreenProps<NavigationState>;
 type Props = ReduxMappedProps & ReduxProps & OwnProps;
 const LOGIN_BASE_URL = `${config.apiUrlPrefix}/login?entityID=`;
 /**

--- a/ts/screens/authentication/IdpSelectionScreen.tsx
+++ b/ts/screens/authentication/IdpSelectionScreen.tsx
@@ -10,7 +10,7 @@ import {
 } from "native-base";
 import * as React from "react";
 import { Image, StyleSheet } from "react-native";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
 
 import IdpsGrid from "../../components/IdpsGrid";
@@ -23,9 +23,7 @@ import { idpSelected } from "../../store/actions/authentication";
 import { ReduxProps } from "../../store/actions/types";
 
 type ReduxMappedProps = {};
-type OwnProps = {
-  navigation: NavigationScreenProp<NavigationState>;
-};
+type OwnProps = NavigationScreenProps<NavigationState>;
 type Props = ReduxMappedProps & ReduxProps & OwnProps;
 const idps: ReadonlyArray<IdentityProvider> = [
   {

--- a/ts/screens/authentication/LandingScreen.tsx
+++ b/ts/screens/authentication/LandingScreen.tsx
@@ -1,7 +1,7 @@
 import { Body, Button, Container, Content, Text, View } from "native-base";
 import * as React from "react";
 import DeviceInfo from "react-native-device-info";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
 import AppHeader from "../../components/ui/AppHeader";
 import IconFont from "../../components/ui/IconFont";
@@ -11,9 +11,7 @@ import { ReduxProps } from "../../store/actions/types";
 import variables from "../../theme/variables";
 
 type ReduxMappedProps = {};
-type OwnProps = {
-  navigation: NavigationScreenProp<NavigationState>;
-};
+type OwnProps = NavigationScreenProps<NavigationState>;
 type Props = ReduxMappedProps & ReduxProps & OwnProps;
 /**
  * A screen where the user can choose to login with SPID or get more informations.

--- a/ts/screens/authentication/SpidInformationRequestScreen.tsx
+++ b/ts/screens/authentication/SpidInformationRequestScreen.tsx
@@ -9,7 +9,7 @@ import {
   View
 } from "native-base";
 import * as React from "react";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
 import { isValid } from "redux-form";
 import SpidInformationForm, {
@@ -26,9 +26,7 @@ import { GlobalState } from "../../store/reducers/types";
 type ReduxMappedProps = {
   isFormValid: boolean;
 };
-type OwnProps = {
-  navigation: NavigationScreenProp<NavigationState>;
-};
+type OwnProps = NavigationScreenProps<NavigationState>;
 
 type Props = ReduxMappedProps & OwnProps & ContextualHelpInjectedProps;
 

--- a/ts/screens/messages/MessageDetailsScreen.tsx
+++ b/ts/screens/messages/MessageDetailsScreen.tsx
@@ -1,10 +1,6 @@
 import { Body, Button, Container, Content, H1, Left, Text } from "native-base";
 import * as React from "react";
-import {
-  NavigationInjectedProps,
-  NavigationScreenProp,
-  NavigationState
-} from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 import MessageDetailsComponent from "../../components/messages/MessageDetailsComponent";
 import AppHeader from "../../components/ui/AppHeader";
 import IconFont from "../../components/ui/IconFont";
@@ -23,15 +19,13 @@ interface ParamType {
   readonly details: ParamTypeObject;
 }
 
-interface StateParams extends NavigationState {
+interface StateParams {
   readonly params: ParamType;
 }
 
-type OwnProps = Readonly<{
-  navigation: NavigationScreenProp<StateParams>;
-}>;
+type OwnProps = NavigationScreenProps<NavigationState & StateParams>;
 
-type Props = OwnProps & NavigationInjectedProps;
+type Props = OwnProps;
 
 /**
  * This screen show the Message Details for a simple message

--- a/ts/screens/messages/MessagesScreen.tsx
+++ b/ts/screens/messages/MessagesScreen.tsx
@@ -5,9 +5,13 @@ import { ActivityIndicator, FlatList, StyleSheet } from "react-native";
 import {
   NavigationEventSubscription,
   NavigationScreenProp,
-  NavigationState
+  NavigationState,
+  NavigationScreenComponent,
+  NavigationRoute,
+  NavigationComponent,
+  NavigationScreenProps
 } from "react-navigation";
-import { connect } from "react-redux";
+import { connect, MapStateToPropsParam } from "react-redux";
 
 import MessageComponent from "../../components/messages/MessageComponent";
 import I18n from "../../i18n";
@@ -27,9 +31,7 @@ type ReduxMappedProps = Readonly<{
   services: ServicesState;
 }>;
 
-export type OwnProps = Readonly<{
-  navigation: NavigationScreenProp<NavigationState>;
-}>;
+export type OwnProps = NavigationScreenProps<any, any>;
 
 export type IMessageDetails = Readonly<{
   item: Readonly<MessageWithContentPO>;
@@ -165,12 +167,23 @@ class MessagesScreen extends React.Component<Props, never> {
   }
 }
 
-const mapStateToProps = (state: GlobalState): ReduxMappedProps => ({
+const mapStateToProps: MapStateToPropsParam<
+  ReduxMappedProps,
+  OwnProps,
+  GlobalState
+> = (state: GlobalState): ReduxMappedProps => ({
   isLoadingMessages: createLoadingSelector([FetchRequestActions.MESSAGES_LOAD])(
     state
   ),
   messages: orderedMessagesSelector(state),
   services: state.entities.services
 });
+
+const X: NavigationScreenComponent<any, any, any> = connect<
+  ReduxMappedProps,
+  {},
+  OwnProps,
+  GlobalState
+>(mapStateToProps)(MessagesScreen);
 
 export default connect(mapStateToProps)(MessagesScreen);

--- a/ts/screens/messages/MessagesScreen.tsx
+++ b/ts/screens/messages/MessagesScreen.tsx
@@ -4,14 +4,10 @@ import { Container, H1, Tab, Tabs, View } from "native-base";
 import { ActivityIndicator, FlatList, StyleSheet } from "react-native";
 import {
   NavigationEventSubscription,
-  NavigationScreenProp,
-  NavigationState,
-  NavigationScreenComponent,
-  NavigationRoute,
-  NavigationComponent,
-  NavigationScreenProps
+  NavigationScreenProps,
+  NavigationState
 } from "react-navigation";
-import { connect, MapStateToPropsParam } from "react-redux";
+import { connect } from "react-redux";
 
 import MessageComponent from "../../components/messages/MessageComponent";
 import I18n from "../../i18n";
@@ -31,7 +27,7 @@ type ReduxMappedProps = Readonly<{
   services: ServicesState;
 }>;
 
-export type OwnProps = NavigationScreenProps<any, any>;
+export type OwnProps = NavigationScreenProps<NavigationState>;
 
 export type IMessageDetails = Readonly<{
   item: Readonly<MessageWithContentPO>;
@@ -167,23 +163,12 @@ class MessagesScreen extends React.Component<Props, never> {
   }
 }
 
-const mapStateToProps: MapStateToPropsParam<
-  ReduxMappedProps,
-  OwnProps,
-  GlobalState
-> = (state: GlobalState): ReduxMappedProps => ({
+const mapStateToProps = (state: GlobalState): ReduxMappedProps => ({
   isLoadingMessages: createLoadingSelector([FetchRequestActions.MESSAGES_LOAD])(
     state
   ),
   messages: orderedMessagesSelector(state),
   services: state.entities.services
 });
-
-const X: NavigationScreenComponent<any, any, any> = connect<
-  ReduxMappedProps,
-  {},
-  OwnProps,
-  GlobalState
->(mapStateToProps)(MessagesScreen);
 
 export default connect(mapStateToProps)(MessagesScreen);

--- a/ts/screens/onboarding/PinScreen.tsx
+++ b/ts/screens/onboarding/PinScreen.tsx
@@ -11,7 +11,7 @@ import {
 } from "native-base";
 import * as React from "react";
 import CodeInput from "react-native-confirmation-code-input";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
 import Pinpad from "../../components/Pinpad";
 import AppHeader from "../../components/ui/AppHeader";
@@ -28,9 +28,7 @@ type ReduxMappedProps = {
   pinSaveError: Option<string>;
 };
 
-type OwnProps = {
-  navigation: NavigationScreenProp<NavigationState>;
-};
+type OwnProps = NavigationScreenProps<NavigationState>;
 
 type Props = ReduxMappedProps & ReduxProps & OwnProps;
 

--- a/ts/screens/onboarding/TosScreen.tsx
+++ b/ts/screens/onboarding/TosScreen.tsx
@@ -10,7 +10,7 @@ import {
   View
 } from "native-base";
 import * as React from "react";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
 import AppHeader from "../../components/ui/AppHeader";
 import IconFont from "../../components/ui/IconFont";
@@ -18,9 +18,7 @@ import I18n from "../../i18n";
 import { acceptTos } from "../../store/actions/onboarding";
 import { ReduxProps } from "../../store/actions/types";
 type ReduxMappedProps = {};
-type OwnProps = {
-  navigation: NavigationScreenProp<NavigationState>;
-};
+type OwnProps = NavigationScreenProps<NavigationState>;
 type Props = ReduxMappedProps & ReduxProps & OwnProps;
 /**
  * A screen to show the ToS to the user.

--- a/ts/screens/wallet/AddCardScreen.tsx
+++ b/ts/screens/wallet/AddCardScreen.tsx
@@ -17,7 +17,7 @@ import {
 import * as React from "react";
 import { FlatList, Image, ScrollView, StyleSheet } from "react-native";
 import { Col, Grid } from "react-native-easy-grid";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 import { LabelledItem } from "../../components/LabelledItem";
 import { WalletStyles } from "../../components/styles/wallet";
 import AppHeader from "../../components/ui/AppHeader";
@@ -28,9 +28,9 @@ import Icon from "../../theme/font-icons/io-icon-font";
 import variables from "../../theme/variables";
 import { fixExpirationDate, fixPan } from "../../utils/input";
 
-type Props = Readonly<{
-  navigation: NavigationScreenProp<NavigationState>;
-}>;
+type OwnProps = NavigationScreenProps<NavigationState>;
+
+type Props = OwnProps;
 
 type State = Readonly<{
   pan: Option<string>;

--- a/ts/screens/wallet/AddManagerToCardScreen.tsx
+++ b/ts/screens/wallet/AddManagerToCardScreen.tsx
@@ -17,7 +17,7 @@ import {
 import * as React from "react";
 import { FlatList, Image, StyleSheet } from "react-native";
 import { Col, Grid, Row } from "react-native-easy-grid";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 import { WalletAPI } from "../../api/wallet/wallet-api";
 import { WalletStyles } from "../../components/styles/wallet";
 import AppHeader from "../../components/ui/AppHeader";
@@ -25,9 +25,9 @@ import I18n from "../../i18n";
 import variables from "../../theme/variables";
 import { TransactionManager } from "../../types/wallet";
 
-type Props = Readonly<{
-  navigation: NavigationScreenProp<NavigationState>;
-}>;
+type OwnProps = NavigationScreenProps<NavigationState>;
+
+type Props = OwnProps;
 
 const paymentManagers: ReadonlyArray<
   TransactionManager

--- a/ts/screens/wallet/AddPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/AddPaymentMethodScreen.tsx
@@ -22,7 +22,7 @@ import {
   View
 } from "native-base";
 import * as React from "react";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 import { WalletAPI } from "../../api/wallet/wallet-api";
 import { WalletStyles } from "../../components/styles/wallet";
 import AppHeader from "../../components/ui/AppHeader";
@@ -33,9 +33,9 @@ import I18n from "../../i18n";
 import variables from "../../theme/variables";
 import { TransactionSummary } from "../../types/wallet";
 
-type Props = Readonly<{
-  navigation: NavigationScreenProp<NavigationState>;
-}>;
+type OwnProps = NavigationScreenProps<NavigationState>;
+
+type Props = OwnProps;
 
 const transaction: Readonly<
   TransactionSummary

--- a/ts/screens/wallet/ChoosePaymentMethodScreen.tsx
+++ b/ts/screens/wallet/ChoosePaymentMethodScreen.tsx
@@ -16,7 +16,7 @@ import {
   View
 } from "native-base";
 import * as React from "react";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
 import { WalletStyles } from "../../components/styles/wallet";
 import AppHeader from "../../components/ui/AppHeader";
@@ -36,9 +36,7 @@ type ReduxMappedStateProps = Readonly<{
   transaction: Readonly<WalletTransaction>;
 }>;
 
-type OwnProps = Readonly<{
-  navigation: NavigationScreenProp<NavigationState>;
-}>;
+type OwnProps = NavigationScreenProps<NavigationState>;
 
 type Props = OwnProps & ReduxMappedStateProps;
 

--- a/ts/screens/wallet/ConfirmSaveCardScreen.tsx
+++ b/ts/screens/wallet/ConfirmSaveCardScreen.tsx
@@ -15,7 +15,7 @@ import {
 import * as React from "react";
 import { Switch } from "react-native";
 import { Col, Grid } from "react-native-easy-grid";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
 import AppHeader from "../../components/ui/AppHeader";
 import IconFont from "../../components/ui/IconFont";
@@ -29,9 +29,7 @@ type ReduxMappedStateProps = Readonly<{
   card: Readonly<CreditCard>;
 }>;
 
-type OwnProps = Readonly<{
-  navigation: NavigationScreenProp<NavigationState>;
-}>;
+type OwnProps = NavigationScreenProps<NavigationState>;
 
 type Props = OwnProps & ReduxMappedStateProps;
 

--- a/ts/screens/wallet/ConfirmToProceedTransactionScreen.tsx
+++ b/ts/screens/wallet/ConfirmToProceedTransactionScreen.tsx
@@ -19,7 +19,7 @@ import {
 import * as React from "react";
 import { StyleSheet } from "react-native";
 import { Col, Grid, Row } from "react-native-easy-grid";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
 import { WalletStyles } from "../../components/styles/wallet";
 import AppHeader from "../../components/ui/AppHeader";
@@ -38,9 +38,7 @@ type ReduxMappedStateProps = Readonly<{
   transaction: Readonly<WalletTransaction>;
 }>;
 
-type OwnProps = Readonly<{
-  navigation: NavigationScreenProp<NavigationState>;
-}>;
+type OwnProps = NavigationScreenProps<NavigationState>;
 
 type Props = OwnProps & ReduxMappedStateProps;
 

--- a/ts/screens/wallet/CreditCardsScreen.tsx
+++ b/ts/screens/wallet/CreditCardsScreen.tsx
@@ -11,7 +11,7 @@ import { WalletLayout } from "../../components/wallet/WalletLayout";
 import I18n from "../../i18n";
 
 import { Button } from "native-base";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
 import CreditCardComponent from "../../components/wallet/card";
 import ROUTES from "../../navigation/routes";
@@ -23,9 +23,7 @@ type ReduxMappedStateProps = Readonly<{
   cards: ReadonlyArray<CreditCard>;
 }>;
 
-type OwnProps = Readonly<{
-  navigation: NavigationScreenProp<NavigationState>;
-}>;
+type OwnProps = NavigationScreenProps<NavigationState>;
 
 type Props = OwnProps & ReduxMappedStateProps;
 

--- a/ts/screens/wallet/FirstTransactionSummaryScreen.tsx
+++ b/ts/screens/wallet/FirstTransactionSummaryScreen.tsx
@@ -22,7 +22,7 @@ import {
 import * as React from "react";
 import { Image, StyleSheet } from "react-native";
 import { Col, Grid, Row } from "react-native-easy-grid";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 import { WalletAPI } from "../../api/wallet/wallet-api";
 import { WalletStyles } from "../../components/styles/wallet";
 import AppHeader from "../../components/ui/AppHeader";
@@ -36,9 +36,9 @@ import {
   TransactionSubject
 } from "../../types/wallet";
 
-type Props = Readonly<{
-  navigation: NavigationScreenProp<NavigationState>;
-}>;
+type OwnProps = NavigationScreenProps<NavigationState>;
+
+type Props = OwnProps;
 
 const styles = StyleSheet.create({
   padded: {

--- a/ts/screens/wallet/ManuallyIdentifyTransactionScreen.tsx
+++ b/ts/screens/wallet/ManuallyIdentifyTransactionScreen.tsx
@@ -25,14 +25,14 @@ import {
   View
 } from "native-base";
 import * as React from "react";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 import AppHeader from "../../components/ui/AppHeader";
 import I18n from "../../i18n";
 import ROUTES from "../../navigation/routes";
 
-type Props = Readonly<{
-  navigation: NavigationScreenProp<NavigationState>;
-}>;
+type OwnProps = NavigationScreenProps<NavigationState>;
+
+type Props = OwnProps;
 
 type State = Readonly<{
   transactionCode: Option<string>;

--- a/ts/screens/wallet/QRcodeAcquisitionByScannerScreen.tsx
+++ b/ts/screens/wallet/QRcodeAcquisitionByScannerScreen.tsx
@@ -16,14 +16,14 @@ import {
 import * as React from "react";
 import { Dimensions, ScrollView, StyleSheet } from "react-native";
 import QRCodeScanner from "react-native-qrcode-scanner";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 import AppHeader from "../../components/ui/AppHeader";
 import I18n from "../../i18n";
 import variables from "../../theme/variables";
 
-type Props = Readonly<{
-  navigation: NavigationScreenProp<NavigationState>;
-}>;
+type OwnProps = NavigationScreenProps<NavigationState>;
+
+type Props = OwnProps;
 
 const screenWidth = Dimensions.get("screen").width;
 

--- a/ts/screens/wallet/TransactionDetailsScreen.tsx
+++ b/ts/screens/wallet/TransactionDetailsScreen.tsx
@@ -16,7 +16,7 @@ import * as React from "react";
 import { Content, H1, H3, Text, View } from "native-base";
 import { StyleSheet } from "react-native";
 import { Col, Grid, Row } from "react-native-easy-grid";
-import { NavigationInjectedProps } from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
 import { WalletStyles } from "../../components/styles/wallet";
 import { CardEnum, WalletLayout } from "../../components/wallet/WalletLayout";
@@ -34,7 +34,9 @@ type ReduxMappedProps = Readonly<{
   selectedCard: CreditCard;
 }>;
 
-type Props = ReduxMappedProps & NavigationInjectedProps;
+type OwnProps = NavigationScreenProps<NavigationState>;
+
+type Props = ReduxMappedProps & OwnProps;
 
 /**
  * isTransactionStarted will be true when the user accepted to proceed with a transaction

--- a/ts/screens/wallet/TransactionsScreen.tsx
+++ b/ts/screens/wallet/TransactionsScreen.tsx
@@ -6,11 +6,7 @@ import * as React from "react";
 import I18n from "../../i18n";
 
 import { Text, View } from "native-base";
-import {
-  NavigationInjectedProps,
-  NavigationScreenProp,
-  NavigationState
-} from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 
 import { connect } from "react-redux";
 import { WalletStyles } from "../../components/styles/wallet";
@@ -26,19 +22,16 @@ interface ParamType {
   readonly card: CreditCard;
 }
 
-interface StateParams extends NavigationState {
+interface StateParams {
   readonly params: ParamType;
-}
-
-interface OwnProps {
-  readonly navigation: NavigationScreenProp<StateParams>;
 }
 
 type ReduxMappedProps = Readonly<{
   selectedCard: CreditCard;
 }>;
 
-type Props = ReduxMappedProps & OwnProps & NavigationInjectedProps;
+type Props = ReduxMappedProps &
+  NavigationScreenProps<NavigationState & StateParams>;
 
 class TransactionsScreen extends React.Component<Props, never> {
   public render(): React.ReactNode {

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -6,7 +6,7 @@
 import { Button, H1, Left, Right, Text, View } from "native-base";
 import * as React from "react";
 import { Image, StyleSheet } from "react-native";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationScreenProps, NavigationState } from "react-navigation";
 import { connect, Dispatch } from "react-redux";
 import { WalletStyles } from "../../components/styles/wallet";
 
@@ -34,9 +34,7 @@ type ReduxMappedDispatchProps = Readonly<{
   loadCards: () => void;
 }>;
 
-type OwnProps = Readonly<{
-  navigation: NavigationScreenProp<NavigationState>;
-}>;
+type OwnProps = NavigationScreenProps<NavigationState>;
 
 type Props = ReduxMappedStateProps &
   ReduxMappedDispatchProps &

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -187,7 +187,9 @@ const mapStateToProps = (state: GlobalState): ReduxMappedStateProps => ({
   cardsNumber: creditCardsSelector(state).length
 });
 
-const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedDispatchProps => ({
+const mapDispatchToProps = (
+  dispatch: Dispatch<GlobalState>
+): ReduxMappedDispatchProps => ({
   loadTransactions: () => dispatch(fetchTransactionsRequest()),
   loadCards: () => dispatch(fetchCardsRequest())
 });

--- a/ts/types/redux_navigation.ts
+++ b/ts/types/redux_navigation.ts
@@ -1,0 +1,27 @@
+import { NavigationScreenComponent } from "react-navigation";
+
+/**
+ * Helper type for safe casting a redux mapped component to a component
+ * suitable for be configured in a `NavigationRouteConfigMap`.
+ *
+ * This is necessary due to some limitation in the react-navigation types defs:
+ * `NavigationRouteConfigMap` wants the `screen` property to refer to a
+ * `NavigationScreenComponent<any, any, any>` - when we wrap a component with
+ * Redux's `connect` we get a type that cannot be cast automatically by
+ * typescript to `NavigationScreenComponent<any, any, any>`.
+ *
+ * Example:
+ *
+ * ```
+ * [ROUTES.MESSAGES_LIST]: {
+ *   screen: MessagesScreen as SafeNavigationScreenComponent<
+ *     typeof MessagesScreen
+ *   >
+ * },
+ * ```
+ */
+export type SafeNavigationScreenComponent<
+  T
+> = T extends NavigationScreenComponent<infer T1, infer T2, infer T3>
+  ? NavigationScreenComponent<any, any, any>
+  : T;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "noUnusedParameters": true,
     "noUnusedLocals": true,
     "strictFunctionTypes": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "noErrorTruncation": true
   },
   "lib": [ "dom", "es2015", "es2016" ],
   "exclude": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -631,12 +631,12 @@
     "@types/react" "*"
     "@types/react-native" "*"
 
-"@types/react-redux@^5.0.18":
-  version "5.0.18"
-  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-5.0.18.tgz#95fdcce00b617b93c98a3684ed6666e75d8a669e"
+"@types/react-redux@^5.0.20":
+  version "5.0.20"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-5.0.20.tgz#a332f2a97043d6127159956a4639a9fb5dc1f5dc"
   dependencies:
     "@types/react" "*"
-    redux "^4.0.0"
+    redux "^3.6.0"
 
 "@types/react-test-renderer@^16.0.1":
   version "16.0.1"
@@ -644,13 +644,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "16.3.12"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.12.tgz#68d9146f3e9797e38ffbf22f7ed1dde91a2cfd2e"
-  dependencies:
-    csstype "^2.2.0"
-
-"@types/react@16.3.16":
+"@types/react@*", "@types/react@16.3.16":
   version "16.3.16"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.16.tgz#78fc44a90b45701f50c8a7008f733680ba51fc86"
   dependencies:
@@ -6303,7 +6297,7 @@ redux-saga@*, redux-saga@^0.16.0:
   version "0.16.0"
   resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-0.16.0.tgz#0a231db0a1489301dd980f6f2f88d8ced418f724"
 
-redux@4.0.0, redux@^4.0.0:
+redux@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.0.tgz#aa698a92b729315d22b34a0553d7e6533555cc03"
   dependencies:


### PR DESCRIPTION
@fpersico there's a problem with the most recent redux types, the way we configure navigation doesn't work anymore, see [here](https://github.com/teamdigitale/italia-app/pull/258/files#diff-f0860587f8c9820ec68edcbe7a1955e6R16) - the components we use for the screens must be compatible with the type `NavigationComponent` 