### PR TITLE
Enables tslint-language-service

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "tslint-config-prettier": "^1.13.0",
     "tslint-eslint-rules": "^5.3.1",
     "tslint-immutable": "^4.6.0",
+    "tslint-language-service": "^0.9.9",
     "tslint-plugin-prettier": "^1.3.0",
     "tslint-react": "^3.5.1",
     "tslint-sonarts": "^1.7.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,13 @@
     "noUnusedParameters": true,
     "noUnusedLocals": true,
     "strictFunctionTypes": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "plugins": [
+      {
+        "name": "tslint-language-service",
+        "supressWhileTypeErrorsPresent": true
+      }
+    ]
   },
   "lib": [ "dom", "es2015", "es2016" ],
   "exclude": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1850,6 +1850,12 @@ call-me-maybe@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
 
+caller-id@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/caller-id/-/caller-id-0.1.0.tgz#59bdac0893d12c3871408279231f97458364f07b"
+  dependencies:
+    stack-trace "~0.0.7"
+
 callsites@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
@@ -5248,6 +5254,12 @@ mixin-deep@^1.2.0:
   dependencies:
     minimist "0.0.8"
 
+mock-require@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/mock-require/-/mock-require-2.0.2.tgz#1eaa71aad23013773d127dc7e91a3fbb4837d60d"
+  dependencies:
+    caller-id "^0.1.0"
+
 morgan@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.0.tgz#d01fa6c65859b76fcf31b3cb53a3821a311d8051"
@@ -7039,7 +7051,7 @@ stack-generator@^2.0.1:
   dependencies:
     stackframe "^1.0.4"
 
-stack-trace@0.0.x:
+stack-trace@0.0.x, stack-trace@~0.0.7:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
 
@@ -7420,6 +7432,12 @@ tslint-eslint-rules@^5.3.1:
 tslint-immutable@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/tslint-immutable/-/tslint-immutable-4.6.0.tgz#b93f50961c499e331d919084140f5034b84e80af"
+
+tslint-language-service@^0.9.9:
+  version "0.9.9"
+  resolved "https://registry.yarnpkg.com/tslint-language-service/-/tslint-language-service-0.9.9.tgz#f546dc38483979e6fb3cfa59584ad8525b3ad4da"
+  dependencies:
+    mock-require "^2.0.2"
 
 tslint-microsoft-contrib@^5.0.3:
   version "5.0.3"


### PR DESCRIPTION
This makes tslint running inside the editor much faster,
see https://github.com/angelozerr/tslint-language-service/blob/master/README.md