### PR TITLE
[#159294221] Set authLevel as parameter in the IDP login url

### DIFF
--- a/ts/screens/authentication/IdpLoginScreen.tsx
+++ b/ts/screens/authentication/IdpLoginScreen.tsx
@@ -24,7 +24,9 @@ type OwnProps = {
   navigation: NavigationScreenProp<NavigationState>;
 };
 type Props = ReduxMappedProps & ReduxProps & OwnProps;
-const LOGIN_BASE_URL = `${config.apiUrlPrefix}/login?entityID=`;
+const LOGIN_BASE_URL = `${
+  config.apiUrlPrefix
+}/login?authLevel=SpidL2&entityID=`;
 /**
  * A screen that allow the user to login with an IDP.
  * The IDP page is opened in a WebView


### PR DESCRIPTION
The authLevel is now fixed to SpidL2. If necessary in another story we can make it dynamic.