### PR TITLE
Extend prettifier to tsx and fix it for bash

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "postinstall": "patch-package && chmod +x ./bin/add-ios-source-maps.sh && ./bin/add-ios-source-maps.sh && chmod +x ./bin/add-ios-env-config.sh && ./bin/add-ios-env-config.sh",
     "test": "jest",
-    "prettify": "prettier --write ts/**/*.ts*",
+    "prettify": "prettier --write \"ts/**/*.ts*\"",
     "packager:clear": "rm -rf $TMPDIR/react-native-packager-cache-* && rm -rf $TMPDIR/metro-bundler-cache-*",
     "bundle:android": "node node_modules/react-native/local-cli/cli.js bundle --platform android --dev true --entry-file index.js --bundle-output ./bundles/index.android.bundle",
     "tsc:noemit": "tsc --noemit",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "postinstall": "patch-package && chmod +x ./bin/add-ios-source-maps.sh && ./bin/add-ios-source-maps.sh && chmod +x ./bin/add-ios-env-config.sh && ./bin/add-ios-env-config.sh",
     "test": "jest",
-    "prettify": "prettier --write 'ts/**/*.ts'",
+    "prettify": "prettier --write ts/**/*.ts*",
     "packager:clear": "rm -rf $TMPDIR/react-native-packager-cache-* && rm -rf $TMPDIR/metro-bundler-cache-*",
     "bundle:android": "node node_modules/react-native/local-cli/cli.js bundle --platform android --dev true --entry-file index.js --bundle-output ./bundles/index.android.bundle",
     "tsc:noemit": "tsc --noemit",


### PR DESCRIPTION
- Extend prettifier execution to `.ts*` files (it includes `.tsx`, instead of only .ts files).
- Replace `'` with `\"` into prettier params, to allow execution on some bash command lines (linux issue) and PowerShell (windows issue)