### PR TITLE
[#159402967] Sets Android main activity mode to singleTask

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -48,6 +48,7 @@
 
       <activity
         android:name=".MainActivity"
+        android:launchMode="singleTask"
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
         android:windowSoftInputMode="adjustResize"


### PR DESCRIPTION
Without this the RootContainer is recreated every time the application go in background and than in foreground.
It is also needed when using deep-linking https://facebook.github.io/react-native/docs/linking.html#handling-deep-links.

NOTE: The documentation about singleTask is:
```
The system creates the activity at the root of a new task and routes the intent to it. However, if an instance of the activity already exists, the system routes the intent to existing instance through a call to its onNewIntent() method, rather than creating a new one.
```