### PR TITLE
[#159195774] Navigate back with Android back button

### DIFF
--- a/ts/components/GoBackButton.tsx
+++ b/ts/components/GoBackButton.tsx
@@ -1,0 +1,70 @@
+import { Button } from "native-base";
+import * as React from "react";
+import { BackHandler } from "react-native";
+import {
+  NavigationScreenProp,
+  NavigationState,
+  withNavigation
+} from "react-navigation";
+import variables from "../theme/variables";
+import IconFont from "./ui/IconFont";
+
+interface NavigationProps {
+  navigation: NavigationScreenProp<NavigationState>;
+}
+
+interface OwnProps {
+  [k: string]: any;
+  onPress?: () => void;
+  white?: boolean;
+}
+
+type Props = NavigationProps & OwnProps;
+
+class GoBackButton extends React.PureComponent<Props> {
+  public static defaultProps: Partial<Props> = {
+    white: false
+  };
+
+  public componentDidMount() {
+    BackHandler.addEventListener("hardwareBackPress", this.handleBackPress);
+  }
+
+  public componentWillUnmount() {
+    BackHandler.removeEventListener("hardwareBackPress", this.handleBackPress);
+  }
+
+  private handleBackPress = () => {
+    this.getOnPressHandler()();
+
+    return true;
+  };
+
+  private handleOnPressDefault = () => this.props.navigation.goBack(null);
+
+  private getOnPressHandler = () =>
+    typeof this.props.onPress === "function"
+      ? this.props.onPress
+      : this.handleOnPressDefault;
+
+  public render() {
+    const { white, ...restProps } = this.props;
+
+    const buttonProps = {
+      transparent: true,
+      ...restProps,
+      onPress: this.getOnPressHandler()
+    };
+
+    return (
+      <Button {...buttonProps}>
+        <IconFont
+          name="io-back"
+          style={{ color: white ? variables.colorWhite : undefined }}
+        />
+      </Button>
+    );
+  }
+}
+
+export default withNavigation(GoBackButton);

--- a/ts/components/screens/BaseScreenComponent.tsx
+++ b/ts/components/screens/BaseScreenComponent.tsx
@@ -1,4 +1,4 @@
-import { Body, Button, Container, Left, Right, Text } from "native-base";
+import { Body, Container, Left, Right, Text } from "native-base";
 import { connectStyle } from "native-base-shoutem-theme";
 import mapPropsToStyleNames from "native-base/src/utils/mapPropsToStyleNames";
 import * as React from "react";
@@ -9,6 +9,7 @@ import AppHeader from "../ui/AppHeader";
 
 import { DEFAULT_APPLICATION_NAME } from "../../config";
 import { ContextualHelp } from "../ContextualHelp";
+import GoBackButton from "../GoBackButton";
 
 interface ContextualHelpProps {
   title: string;
@@ -49,13 +50,11 @@ class BaseScreenComponent extends React.PureComponent<Props, State> {
     return (
       <Container>
         <AppHeader primary={this.props.primary}>
-          <Left>
-            {goBack && (
-              <Button transparent={true} onPress={goBack}>
-                <IconFont name="io-back" />
-              </Button>
-            )}
-          </Left>
+          {goBack && (
+            <Left>
+              <GoBackButton onPress={goBack} />
+            </Left>
+          )}
           <Body>
             <Text white={this.props.primary}>
               {headerTitle || DEFAULT_APPLICATION_NAME}

--- a/ts/components/wallet/WalletLayout.tsx
+++ b/ts/components/wallet/WalletLayout.tsx
@@ -8,14 +8,20 @@
  * footer with a button for starting a new payment
  */
 import { Body, Container, Content, Text, View } from "native-base";
-import { Left } from "native-base";
 import { Button } from "native-base";
+import { Left } from "native-base";
 import * as React from "react";
 import { ScrollView } from "react-native";
 import { Image, StyleSheet, TouchableHighlight } from "react-native";
 import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
-import IconFont from "../../components/ui/IconFont";
+
+import GoBackButton from "../GoBackButton";
+import AppHeader from "../ui/AppHeader";
+import IconFont from "../ui/IconFont";
+import CardComponent from "./card";
+import { LogoPosition } from "./card/Logo";
+
 import I18n from "../../i18n";
 import ROUTES from "../../navigation/routes";
 import { Dispatch } from "../../store/actions/types";
@@ -23,9 +29,6 @@ import { paymentRequestQrCode } from "../../store/actions/wallet/payment";
 import variables from "../../theme/variables";
 import { Wallet } from "../../types/pagopa";
 import { WalletStyles } from "../styles/wallet";
-import AppHeader from "../ui/AppHeader";
-import CardComponent from "./card";
-import { LogoPosition } from "./card/Logo";
 
 const styles = StyleSheet.create({
   darkGrayBg: {
@@ -154,26 +157,11 @@ class WalletLayout extends React.Component<Props> {
     return (
       <Container>
         <AppHeader style={styles.darkGrayBg}>
-          <Left>
-            <Button
-              transparent={true}
-              onPress={_ =>
-                this.props.allowGoBack
-                  ? this.props.navigation.goBack()
-                  : undefined
-              }
-            >
-              {this.props.allowGoBack && (
-                <IconFont
-                  name="io-back"
-                  style={{
-                    color: variables.colorWhite,
-                    fontSize: variables.iconSize3
-                  }}
-                />
-              )}
-            </Button>
-          </Left>
+          {this.props.allowGoBack && (
+            <Left>
+              <GoBackButton white={true} />
+            </Left>
+          )}
           <Body>
             <Text style={WalletStyles.white}>{this.props.title}</Text>
           </Body>

--- a/ts/screens/authentication/IdpLoginScreen.tsx
+++ b/ts/screens/authentication/IdpLoginScreen.tsx
@@ -1,11 +1,11 @@
-import { Body, Button, Container, Left, Text } from "native-base";
+import { Body, Container, Left, Text } from "native-base";
 import * as React from "react";
 import { NavState, WebView } from "react-native";
 import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
 
+import GoBackButton from "../../components/GoBackButton";
 import AppHeader from "../../components/ui/AppHeader";
-import IconFont from "../../components/ui/IconFont";
 
 import * as config from "../../config";
 
@@ -77,7 +77,6 @@ const IdpLoginScreen: React.SFC<Props> = props => {
     return null;
   }
   const loginUri = LOGIN_BASE_URL + loggedOutWithIdpAuth.idp.entityID;
-  const goBack = () => props.navigation.goBack();
 
   const navigationStateHandler = onNavigationStateChange(
     () => props.dispatch(loginFailure()),
@@ -88,9 +87,7 @@ const IdpLoginScreen: React.SFC<Props> = props => {
     <Container>
       <AppHeader>
         <Left>
-          <Button transparent={true} onPress={goBack} testID="back-button">
-            <IconFont name="io-back" />
-          </Button>
+          <GoBackButton testID="back-button" />
         </Left>
         <Body>
           <Text>

--- a/ts/screens/authentication/SpidInformationRequestScreen.tsx
+++ b/ts/screens/authentication/SpidInformationRequestScreen.tsx
@@ -79,12 +79,15 @@ class SpidInformationRequestScreen extends React.PureComponent<Props> {
     );
   }
 }
+
+const isFormValidSelector = isValid(SPID_INFORMATION_FORM_NAME);
+
 const mapStateToProps = (state: GlobalState): ReduxMappedProps => ({
   /**
    * Our form submit button is outside the `Form` itself so we need to use
    * this selector to check if the form is valid or not.
    */
-  isFormValid: isValid(SPID_INFORMATION_FORM_NAME)(state)
+  isFormValid: isFormValidSelector(state)
 });
 
 export default connect(mapStateToProps)(

--- a/ts/screens/authentication/SpidInformationScreen.tsx
+++ b/ts/screens/authentication/SpidInformationScreen.tsx
@@ -21,12 +21,12 @@ import { StyleSheet } from "react-native";
 import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
 import DefaultSubscreenHeader from "../../components/DefaultScreenHeader";
+import GoBackButton from "../../components/GoBackButton";
 import {
   ContextualHelpInjectedProps,
   withContextualHelp
 } from "../../components/helpers/withContextualHelp";
 import AppHeader from "../../components/ui/AppHeader";
-import IconFont from "../../components/ui/IconFont";
 import Markdown from "../../components/ui/Markdown";
 import I18n from "../../i18n";
 import variables from "../../theme/variables";
@@ -49,10 +49,6 @@ const styles = StyleSheet.create({
 });
 
 class SpidInformationScreen extends React.Component<Props, never> {
-  private goBack() {
-    this.props.navigation.goBack();
-  }
-
   private getValueContent(value: string, content: string) {
     return (
       <Row style={styles.row}>
@@ -78,9 +74,7 @@ class SpidInformationScreen extends React.Component<Props, never> {
       <Container>
         <AppHeader>
           <Left>
-            <Button transparent={true} onPress={_ => this.goBack()}>
-              <IconFont name="io-back" />
-            </Button>
+            <GoBackButton />
           </Left>
           <Body>
             <Text>{I18n.t("authentication.spid_information.headerTitle")}</Text>
@@ -136,11 +130,7 @@ class SpidInformationScreen extends React.Component<Props, never> {
         </Content>
 
         <View footer={true}>
-          <Button
-            block={true}
-            primary={true}
-            onPress={(): void => this.browseToLink()}
-          >
+          <Button block={true} primary={true} onPress={this.browseToLink}>
             <Text>{I18n.t("authentication.spid_information.knowMore")}</Text>
           </Button>
         </View>

--- a/ts/screens/onboarding/PinScreen.tsx
+++ b/ts/screens/onboarding/PinScreen.tsx
@@ -13,6 +13,7 @@ import * as React from "react";
 import CodeInput from "react-native-confirmation-code-input";
 import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
+import GoBackButton from "../../components/GoBackButton";
 import Pinpad from "../../components/Pinpad";
 import AppHeader from "../../components/ui/AppHeader";
 import IconFont from "../../components/ui/IconFont";
@@ -73,10 +74,6 @@ class PinScreen extends React.Component<Props, State> {
         state: "PinUnselected"
       }
     };
-  }
-
-  private goBack() {
-    this.props.navigation.goBack();
   }
 
   // Method called when the first CodeInput is filled
@@ -266,9 +263,7 @@ class PinScreen extends React.Component<Props, State> {
       <Container>
         <AppHeader>
           <Left>
-            <Button transparent={true} onPress={_ => this.goBack()}>
-              <IconFont name="io-back" />
-            </Button>
+            <GoBackButton />
           </Left>
           <Body>
             <Text>{I18n.t("onboarding.tos.headerTitle")}</Text>

--- a/ts/screens/wallet/AddCardScreen.tsx
+++ b/ts/screens/wallet/AddCardScreen.tsx
@@ -5,28 +5,19 @@
 import { none, Option, some } from "fp-ts/lib/Option";
 import { entries, range, size } from "lodash";
 import { Left } from "native-base";
-import {
-  Body,
-  Button,
-  Container,
-  Content,
-  Item,
-  Text,
-  View
-} from "native-base";
+import { Body, Container, Content, Item, Text, View } from "native-base";
 import * as React from "react";
 import { FlatList, Image, ScrollView, StyleSheet } from "react-native";
 import { Col, Grid } from "react-native-easy-grid";
 import { NavigationScreenProp, NavigationState } from "react-navigation";
+import GoBackButton from "../../components/GoBackButton";
 import { LabelledItem } from "../../components/LabelledItem";
 import { WalletStyles } from "../../components/styles/wallet";
 import AppHeader from "../../components/ui/AppHeader";
 import FooterWithButtons from "../../components/ui/FooterWithButtons";
-import IconFont from "../../components/ui/IconFont";
 import { cardIcons } from "../../components/wallet/card/Logo";
 import I18n from "../../i18n";
 import ROUTES from "../../navigation/routes";
-import variables from "../../theme/variables";
 import { fixExpirationDate, fixPan } from "../../utils/input";
 
 type Props = Readonly<{
@@ -113,12 +104,7 @@ export class AddCardScreen extends React.Component<Props, State> {
       <Container>
         <AppHeader>
           <Left>
-            <Button
-              transparent={true}
-              onPress={__ => this.props.navigation.goBack()}
-            >
-              <IconFont name="io-back" size={variables.iconSize3} />
-            </Button>
+            <GoBackButton />
           </Left>
           <Body>
             <Text>{I18n.t("wallet.addCardTitle")}</Text>

--- a/ts/screens/wallet/AddPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/AddPaymentMethodScreen.tsx
@@ -23,13 +23,12 @@ import {
 } from "native-base";
 import * as React from "react";
 import { NavigationScreenProp, NavigationState } from "react-navigation";
+import GoBackButton from "../../components/GoBackButton";
 import { WalletStyles } from "../../components/styles/wallet";
 import AppHeader from "../../components/ui/AppHeader";
-import IconFont from "../../components/ui/IconFont";
 import PaymentBannerComponent from "../../components/wallet/PaymentBannerComponent";
 import PaymentMethodsList from "../../components/wallet/PaymentMethodsList";
 import I18n from "../../i18n";
-import variables from "../../theme/variables";
 
 type Props = Readonly<{
   navigation: NavigationScreenProp<NavigationState>;
@@ -55,12 +54,7 @@ export class AddPaymentMethodScreen extends React.Component<Props, never> {
       <Container>
         <AppHeader>
           <Left>
-            <Button
-              transparent={true}
-              onPress={_ => this.props.navigation.goBack()}
-            >
-              <IconFont name="io-back" size={variables.iconSize3} />
-            </Button>
+            <GoBackButton />
           </Left>
           <Body>
             {this.isInTransaction() ? (

--- a/ts/screens/wallet/ConfirmSaveCardScreen.tsx
+++ b/ts/screens/wallet/ConfirmSaveCardScreen.tsx
@@ -2,24 +2,15 @@
  * This screen presents a summary on the credit card after the user
  * inserted the data required to save a new card
  */
-import {
-  Body,
-  Button,
-  Container,
-  Content,
-  H1,
-  Left,
-  Text,
-  View
-} from "native-base";
+import { Body, Container, Content, H1, Left, Text, View } from "native-base";
 import * as React from "react";
 import { Switch } from "react-native";
 import { Col, Grid } from "react-native-easy-grid";
 import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
+import GoBackButton from "../../components/GoBackButton";
 import AppHeader from "../../components/ui/AppHeader";
 import FooterWithButtons from "../../components/ui/FooterWithButtons";
-import IconFont from "../../components/ui/IconFont";
 import CardComponent from "../../components/wallet/card";
 import I18n from "../../i18n";
 import { GlobalState } from "../../store/reducers/types";
@@ -71,7 +62,7 @@ class ConfirmSaveCardScreen extends React.Component<Props, State> {
       block: true,
       light: true,
       bordered: true,
-      onPress: () => this.goBack(),
+      onPress: this.goBack,
       title: I18n.t("global.buttons.cancel")
     };
 
@@ -79,9 +70,7 @@ class ConfirmSaveCardScreen extends React.Component<Props, State> {
       <Container>
         <AppHeader>
           <Left>
-            <Button transparent={true} onPress={() => this.goBack()}>
-              <IconFont name="io-back" />
-            </Button>
+            <GoBackButton />
           </Left>
           <Body>
             <Text>{I18n.t("wallet.saveCard.header")}</Text>

--- a/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
@@ -25,9 +25,9 @@ import { StyleSheet } from "react-native";
 import { Col, Grid, Row } from "react-native-easy-grid";
 import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
+import GoBackButton from "../../../components/GoBackButton";
 import { WalletStyles } from "../../../components/styles/wallet";
 import AppHeader from "../../../components/ui/AppHeader";
-import IconFont from "../../../components/ui/IconFont";
 import CardComponent from "../../../components/wallet/card";
 import PaymentBannerComponent from "../../../components/wallet/PaymentBannerComponent";
 import I18n from "../../../i18n";
@@ -103,9 +103,7 @@ class ConfirmPaymentMethodScreen extends React.Component<Props, never> {
       <Container>
         <AppHeader>
           <Left>
-            <Button transparent={true} onPress={() => this.props.goBack()}>
-              <IconFont name="io-back" />
-            </Button>
+            <GoBackButton onPress={this.props.goBack} />
           </Left>
           <Body>
             <Text>{I18n.t("wallet.ConfirmPayment.header")}</Text>

--- a/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
@@ -4,7 +4,6 @@
  */
 import {
   Body,
-  Button,
   Container,
   Content,
   H1,
@@ -16,10 +15,10 @@ import {
 import * as React from "react";
 import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
+import GoBackButton from "../../../components/GoBackButton";
 import { WalletStyles } from "../../../components/styles/wallet";
 import AppHeader from "../../../components/ui/AppHeader";
 import FooterWithButtons from "../../../components/ui/FooterWithButtons";
-import IconFont from "../../../components/ui/IconFont";
 import CardComponent from "../../../components/wallet/card";
 import { LogoPosition } from "../../../components/wallet/card/Logo";
 import PaymentBannerComponent from "../../../components/wallet/PaymentBannerComponent";
@@ -81,9 +80,7 @@ class PickPaymentMethodScreen extends React.Component<Props> {
       <Container>
         <AppHeader>
           <Left>
-            <Button transparent={true} onPress={() => this.props.goBack()}>
-              <IconFont name="io-back" />
-            </Button>
+            <GoBackButton onPress={this.props.goBack} />
           </Left>
           <Body>
             <Text>{I18n.t("wallet.payWith.header")}</Text>

--- a/ts/screens/wallet/payment/PickPspScreen.tsx
+++ b/ts/screens/wallet/payment/PickPspScreen.tsx
@@ -3,21 +3,13 @@
  * when it is added to the user wallet
  */
 
-import {
-  Body,
-  Button,
-  Container,
-  Content,
-  H1,
-  Left,
-  Text,
-  View
-} from "native-base";
+import { Body, Container, Content, H1, Left, Text, View } from "native-base";
 import * as React from "react";
 import { FlatList, Image, StyleSheet, TouchableOpacity } from "react-native";
 import { Col, Grid, Row } from "react-native-easy-grid";
 import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
+import GoBackButton from "../../../components/GoBackButton";
 import { WalletStyles } from "../../../components/styles/wallet";
 import AppHeader from "../../../components/ui/AppHeader";
 import IconFont from "../../../components/ui/IconFont";
@@ -90,9 +82,7 @@ class PickPspScreen extends React.Component<Props, never> {
       <Container>
         <AppHeader>
           <Left>
-            <Button transparent={true} onPress={() => this.props.goBack()}>
-              <IconFont name="io-back" />
-            </Button>
+            <GoBackButton onPress={this.props.goBack} />
           </Left>
           <Body>
             <Text>{I18n.t("saveCard.saveCard")}</Text>

--- a/ts/screens/wallet/payment/TransactionSummaryScreen.tsx
+++ b/ts/screens/wallet/payment/TransactionSummaryScreen.tsx
@@ -13,22 +13,14 @@ import {
   PaymentNoticeNumberFromString,
   RptId
 } from "italia-ts-commons/lib/pagopa";
-import {
-  Body,
-  Button,
-  Container,
-  Content,
-  Left,
-  Text,
-  View
-} from "native-base";
+import { Body, Container, Content, Left, Text, View } from "native-base";
 import * as React from "react";
 import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
 import { EnteBeneficiario } from "../../../../definitions/backend/EnteBeneficiario";
+import GoBackButton from "../../../components/GoBackButton";
 import AppHeader from "../../../components/ui/AppHeader";
 import FooterWithButtons from "../../../components/ui/FooterWithButtons";
-import IconFont from "../../../components/ui/IconFont";
 import Markdown from "../../../components/ui/Markdown";
 import PaymentSummaryComponent from "../../../components/wallet/PaymentSummaryComponent";
 import I18n from "../../../i18n";
@@ -47,7 +39,6 @@ import {
   getRptId,
   isGlobalStateWithVerificaResponse
 } from "../../../store/reducers/wallet/payment";
-import variables from "../../../theme/variables";
 import {
   UNKNOWN_PAYMENT_REASON,
   UNKNOWN_RECIPIENT
@@ -124,9 +115,7 @@ class TransactionSummaryScreen extends React.Component<Props, never> {
       <Container>
         <AppHeader>
           <Left>
-            <Button transparent={true} onPress={() => this.props.goBack()}>
-              <IconFont name="io-back" size={variables.iconSize3} />
-            </Button>
+            <GoBackButton onPress={this.props.goBack} />
           </Left>
           <Body>
             <Text>{I18n.t("wallet.firstTransactionSummary.header")}</Text>


### PR DESCRIPTION
Testing the back navigation, I discovered that the `ROUTES.PIN_LOGIN` route is duplicated across `AppNavigator` and `PinNavigator`. Why `PinNavigator` should even exist?
I removed the `PinNavigator` and implemented this behaviour: ater the pin has been validated, the router resets the navigator stack, navigating to `ROUTES.MAIN`, so it's impossible to go back to pin screen.