### PR TITLE
placing "main" button on the right-hand side of the footer

### DIFF
--- a/ts/screens/wallet/payment/ManualDataInsertionScreen.tsx
+++ b/ts/screens/wallet/payment/ManualDataInsertionScreen.tsx
@@ -123,7 +123,7 @@ class ManualDataInsertionScreen extends React.Component<Props, State> {
       block: true,
       primary: true,
       onPress: this.proceedToSummary,
-      title: I18n.t("wallet.insertManually.proceed")
+      title: I18n.t("global.buttons.continue")
     };
 
     const secondaryButtonProps = {
@@ -131,7 +131,7 @@ class ManualDataInsertionScreen extends React.Component<Props, State> {
       light: true,
       bordered: true,
       onPress: () => this.props.navigation.navigate(ROUTES.WALLET_HOME),
-      title: I18n.t("wallet.cancel")
+      title: I18n.t("global.buttons.cancel")
     };
 
     return (
@@ -190,8 +190,9 @@ class ManualDataInsertionScreen extends React.Component<Props, State> {
         </Content>
 
         <FooterWithButtons
-          leftButton={primaryButtonProps}
-          rightButton={secondaryButtonProps}
+          leftButton={secondaryButtonProps}
+          rightButton={primaryButtonProps}
+          inlineHalf={true}
         />
       </Container>
     );

--- a/ts/screens/wallet/payment/TransactionSummaryScreen.tsx
+++ b/ts/screens/wallet/payment/TransactionSummaryScreen.tsx
@@ -154,8 +154,8 @@ class TransactionSummaryScreen extends React.Component<Props, never> {
           </View>
         </Content>
         <FooterWithButtons
-          leftButton={primaryButtonProps}
-          rightButton={secondaryButtonProps}
+          leftButton={secondaryButtonProps}
+          rightButton={primaryButtonProps}
           inlineHalf={true}
         />
       </Container>


### PR DESCRIPTION
PR #341 introduced inline buttons, but in some cases the introduced buttons were "inverted" (i.e. the "main action" button (usually the "continue") could be found on the left-hand side of the footer, while it makes more sense to have it on the right-hand part of it), this PR fixes this problem