### PR TITLE
specifying "keyboardShouldPersistTaps" property from "add card" Scrol…

### DIFF
--- a/ts/screens/wallet/AddCardScreen.tsx
+++ b/ts/screens/wallet/AddCardScreen.tsx
@@ -125,7 +125,11 @@ export class AddCardScreen extends React.Component<Props, State> {
           </Body>
         </AppHeader>
 
-        <ScrollView bounces={false} style={WalletStyles.whiteBg}>
+        <ScrollView
+          bounces={false}
+          style={WalletStyles.whiteBg}
+          keyboardShouldPersistTaps="handled"
+        >
           <Content scrollEnabled={false}>
             <LabelledItem
               label={I18n.t("wallet.dummyCard.labels.holder")}


### PR DESCRIPTION
When filling in the data in the "add card" screen, the user had to tap each input twice (the 1st one dismissed the keyboard, the second set the focus to the right element). 

This behavior is controlled by ScrollView's [keyboardShouldPersistTaps](http://facebook.github.io/react-native/docs/scrollview.html#keyboardshouldpersisttaps). 