### PR TITLE
[#159427678] define "cancel" button behavior in the payment process

### DIFF
--- a/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
@@ -38,6 +38,7 @@ import {
   paymentRequestPickPaymentMethod,
   paymentRequestPickPsp
 } from "../../../store/actions/wallet/payment";
+import { paymentRequestTransactionSummaryFromBanner } from "../../../store/actions/wallet/payment";
 import { GlobalState } from "../../../store/reducers/types";
 import {
   getCurrentAmount,
@@ -49,8 +50,6 @@ import { feeExtractor } from "../../../store/reducers/wallet/wallets";
 import { Wallet } from "../../../types/pagopa";
 import { UNKNOWN_AMOUNT } from "../../../types/unknown";
 import { buildAmount } from "../../../utils/stringBuilder";
-import { paymentRequestTransactionSummaryFromBanner } from "../../../store/actions/wallet/payment";
-
 
 type ReduxMappedStateProps =
   | Readonly<{
@@ -222,7 +221,12 @@ class ConfirmPaymentMethodScreen extends React.Component<Props, never> {
               <Text>{I18n.t("wallet.ConfirmPayment.change")}</Text>
             </Button>
             <View hspacer={true} />
-            <Button style={styles.child} block={true} cancel={true} onPress={this.props.showSummary}>
+            <Button
+              style={styles.child}
+              block={true}
+              cancel={true}
+              onPress={this.props.showSummary}
+            >
               <Text>{I18n.t("global.buttons.cancel")}</Text>
             </Button>
           </View>

--- a/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
@@ -49,6 +49,8 @@ import { feeExtractor } from "../../../store/reducers/wallet/wallets";
 import { Wallet } from "../../../types/pagopa";
 import { UNKNOWN_AMOUNT } from "../../../types/unknown";
 import { buildAmount } from "../../../utils/stringBuilder";
+import { paymentRequestTransactionSummaryFromBanner } from "../../../store/actions/wallet/payment";
+
 
 type ReduxMappedStateProps =
   | Readonly<{
@@ -66,6 +68,7 @@ type ReduxMappedDispatchProps = Readonly<{
   pickPsp: () => void;
   requestCompletion: () => void;
   goBack: () => void;
+  showSummary: () => void;
 }>;
 
 type OwnProps = Readonly<{
@@ -219,7 +222,7 @@ class ConfirmPaymentMethodScreen extends React.Component<Props, never> {
               <Text>{I18n.t("wallet.ConfirmPayment.change")}</Text>
             </Button>
             <View hspacer={true} />
-            <Button style={styles.child} block={true} cancel={true}>
+            <Button style={styles.child} block={true} cancel={true} onPress={this.props.showSummary}>
               <Text>{I18n.t("global.buttons.cancel")}</Text>
             </Button>
           </View>
@@ -251,7 +254,8 @@ const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedDispatchProps => ({
   pickPaymentMethod: () => dispatch(paymentRequestPickPaymentMethod()),
   requestCompletion: () => dispatch(paymentRequestCompletion()),
   goBack: () => dispatch(paymentRequestGoBack()),
-  pickPsp: () => dispatch(paymentRequestPickPsp())
+  pickPsp: () => dispatch(paymentRequestPickPsp()),
+  showSummary: () => dispatch(paymentRequestTransactionSummaryFromBanner())
 });
 
 export default connect(

--- a/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
@@ -28,7 +28,8 @@ import ROUTES from "../../../navigation/routes";
 import { Dispatch } from "../../../store/actions/types";
 import {
   paymentRequestConfirmPaymentMethod,
-  paymentRequestGoBack
+  paymentRequestGoBack,
+  paymentRequestTransactionSummaryFromBanner
 } from "../../../store/actions/wallet/payment";
 import { GlobalState } from "../../../store/reducers/types";
 import { getPaymentStep } from "../../../store/reducers/wallet/payment";
@@ -47,6 +48,7 @@ type ReduxMappedStateProps =
 type ReduxMappedDispatchProps = Readonly<{
   confirmPaymentMethod: (walletId: number) => void;
   goBack: () => void;
+  showSummary: () => void;
 }>;
 
 type OwnProps = Readonly<{
@@ -71,6 +73,7 @@ class PickPaymentMethodScreen extends React.Component<Props> {
     const secondaryButtonProps = {
       block: true,
       cancel: true,
+      onPress: this.props.showSummary,
       title: I18n.t("global.buttons.cancel")
     };
 
@@ -133,7 +136,8 @@ const mapStateToProps = (state: GlobalState): ReduxMappedStateProps =>
 const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedDispatchProps => ({
   confirmPaymentMethod: (walletId: number) =>
     dispatch(paymentRequestConfirmPaymentMethod(walletId)),
-  goBack: () => dispatch(paymentRequestGoBack())
+  goBack: () => dispatch(paymentRequestGoBack()),
+  showSummary: () => dispatch(paymentRequestTransactionSummaryFromBanner())
 });
 
 export default connect(


### PR DESCRIPTION
The requested behavior when pressing "cancel" button in the payment process (for the screens following the transaction recap) is that the navigation is brought back to the "transaction recap" screen (same as what happens when tapping the payment banner). 

This PR implements this behavior for both "pick a payment method" and "confirm payment method" screens