### PR TITLE
[#159491535] Speedup CodeInput focus

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react-native": "0.55.4",
     "react-native-camera": "1.2.0",
     "react-native-config": "^0.11.2",
-    "react-native-confirmation-code-input": "git://github.com/teamdigitale/react-native-confirmation-code-input.git#550ad82",
+    "react-native-confirmation-code-input": "git://github.com/teamdigitale/react-native-confirmation-code-input.git#io",
     "react-native-device-info": "^0.22",
     "react-native-exception-handler": "^2.9.0",
     "react-native-fs": "2.11.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6224,9 +6224,9 @@ react-native-config@^0.11.2:
   version "0.11.5"
   resolved "https://registry.yarnpkg.com/react-native-config/-/react-native-config-0.11.5.tgz#516cb7b6ec437c7739236ca075971db3aabdcb95"
 
-"react-native-confirmation-code-input@git://github.com/teamdigitale/react-native-confirmation-code-input.git#550ad82":
+"react-native-confirmation-code-input@git://github.com/teamdigitale/react-native-confirmation-code-input.git#io":
   version "1.0.1"
-  resolved "git://github.com/teamdigitale/react-native-confirmation-code-input.git#550ad82ed741137eb973164e6eca7cd66ce4f30a"
+  resolved "git://github.com/teamdigitale/react-native-confirmation-code-input.git#eaec9fdeaaf64029e5fcf6fbae7a0e7732c52147"
   dependencies:
     lodash "^4.17.4"
     prop-types "^15.5.10"


### PR DESCRIPTION
The real code change is in the git://github.com/teamdigitale/react-native-confirmation-code-input.git repository.