### PR TITLE
[#159265239] Handle internal link in Markdown component

### DIFF
--- a/ts/components/messages/MessageDetailComponent.tsx
+++ b/ts/components/messages/MessageDetailComponent.tsx
@@ -97,7 +97,9 @@ class MessageDetailComponent extends React.PureComponent<Props, never> {
         />
 
         <View style={styles.markdownContainer}>
-          <Markdown lazy={true}>{message.content.markdown}</Markdown>
+          <Markdown lazyOptions={{ lazy: true }}>
+            {message.content.markdown}
+          </Markdown>
         </View>
       </View>
     );

--- a/ts/components/screens/MarkdownScreenComponent.tsx
+++ b/ts/components/screens/MarkdownScreenComponent.tsx
@@ -2,14 +2,11 @@ import { Content, View } from "native-base";
 import * as React from "react";
 import { InteractionManager } from "react-native";
 
+import themeVariables from "../../theme/variables";
+import { ComponentProps } from "../../types/react";
 import ActivityIndicator from "../ui/ActivityIndicator";
 import Markdown from "../ui/Markdown";
-
 import BaseScreenComponent from "./BaseScreenComponent";
-
-import { ComponentProps } from "../../types/react";
-
-import themeVariables from "../../theme/variables";
 
 interface OwnProps {
   readonly markdown: string;

--- a/ts/components/ui/Markdown/__tests__/index.test.tsx
+++ b/ts/components/ui/Markdown/__tests__/index.test.tsx
@@ -1,13 +1,17 @@
 import * as React from "react";
 import * as renderer from "react-test-renderer";
 
-import Markdown from "../index";
+import { Markdown } from "..";
+
+const mokedDispatch = jest.fn();
 
 describe("Markdown", () => {
   describe("heading", () => {
     it("should render heading1 correctly", () => {
       const tree = renderer
-        .create(<Markdown># A simple heading1</Markdown>)
+        .create(
+          <Markdown dispatch={mokedDispatch}># A simple heading1</Markdown>
+        )
         .toJSON();
 
       expect(tree).toMatchSnapshot();
@@ -15,7 +19,9 @@ describe("Markdown", () => {
 
     it("should render heading2 correctly", () => {
       const tree = renderer
-        .create(<Markdown>## A simple heading2</Markdown>)
+        .create(
+          <Markdown dispatch={mokedDispatch}>## A simple heading2</Markdown>
+        )
         .toJSON();
 
       expect(tree).toMatchSnapshot();
@@ -23,7 +29,9 @@ describe("Markdown", () => {
 
     it("should render heading3 correctly", () => {
       const tree = renderer
-        .create(<Markdown>### A simple heading3</Markdown>)
+        .create(
+          <Markdown dispatch={mokedDispatch}>### A simple heading3</Markdown>
+        )
         .toJSON();
 
       expect(tree).toMatchSnapshot();
@@ -33,7 +41,9 @@ describe("Markdown", () => {
   describe("paragraph", () => {
     it("should render paragraph correctly", () => {
       const tree = renderer
-        .create(<Markdown>A simple paragraph.</Markdown>)
+        .create(
+          <Markdown dispatch={mokedDispatch}>A simple paragraph.</Markdown>
+        )
         .toJSON();
 
       expect(tree).toMatchSnapshot();
@@ -45,6 +55,7 @@ describe("Markdown", () => {
       const tree = renderer
         .create(
           <Markdown
+            dispatch={mokedDispatch}
           >{`A simple unordered list:\n* Vue\n* React\n* Angular`}</Markdown>
         )
         .toJSON();
@@ -56,6 +67,7 @@ describe("Markdown", () => {
       const tree = renderer
         .create(
           <Markdown
+            dispatch={mokedDispatch}
           >{`A simple ordered list:\n1. Vue\n2. React\n3. Angular`}</Markdown>
         )
         .toJSON();

--- a/ts/components/ui/Markdown/rules/link.ts
+++ b/ts/components/ui/Markdown/rules/link.ts
@@ -1,9 +1,40 @@
+import { none, Option, some } from "fp-ts/lib/Option";
 import { Text } from "native-base";
 import * as React from "react";
 import { Linking } from "react-native";
+import { NavigationActions } from "react-navigation";
 import { ReactOutput, SingleASTNode, State } from "simple-markdown";
 
+import ROUTES from "../../../../navigation/routes";
 import { makeReactNativeRule } from "./utils";
+
+// Prefix to match uri like `ioit://PROFILE_MAIN`
+const INTERNAL_TARGET_PREFIX = "ioit://";
+
+// Here we put all the allowed screen name with the mapping to the react-navigation route
+// TODO: Add the other allowed route names
+const ALLOWED_ROUTE_NAMES: ReadonlyArray<string> = [
+  ROUTES.MESSAGES_NAVIGATOR,
+  ROUTES.PREFERENCES_HOME,
+  ROUTES.PREFERENCES_SERVICES,
+  ROUTES.PROFILE_MAIN,
+  ROUTES.WALLET_HOME
+];
+
+function getInternalRoute(target: string): Option<string> {
+  const parsed = target.split(INTERNAL_TARGET_PREFIX);
+
+  if (parsed.length === 2 && parsed[0] === "") {
+    const routeName = parsed[1];
+
+    // Return if available the react-navigation route
+    if (ALLOWED_ROUTE_NAMES.indexOf(routeName) > -1) {
+      return some(routeName);
+    }
+  }
+
+  return none;
+}
 
 function rule() {
   return (
@@ -12,6 +43,27 @@ function rule() {
     state: State
   ): React.ReactNode => {
     const newState = { ...state, withinLink: true };
+    const maybeInternalRoute = getInternalRoute(node.target);
+
+    /** Get a specific onPress handler
+     *
+     * It can be:
+     * () => state.dispatch(NavigationActions.navigate({routeName: internalRoute))} for internal links
+     * () => Linking.openURL(node.target).catch(_ => undefined) for external links
+     * undefined if we can't handle the link
+     */
+    const onPressHandler = maybeInternalRoute.fold(
+      () => Linking.openURL(node.target).catch(_ => undefined),
+      internalRoute =>
+        state.dispatch
+          ? () =>
+              state.dispatch(
+                NavigationActions.navigate({
+                  routeName: internalRoute
+                })
+              )
+          : undefined
+    );
 
     // Create the Text element that must go inside <Button>
     return React.createElement(
@@ -20,7 +72,7 @@ function rule() {
         key: state.key,
         markdown: true,
         link: true,
-        onPress: () => Linking.openURL(node.target).catch(_ => undefined)
+        onPress: onPressHandler
       },
       output(node.content, newState)
     );

--- a/ts/screens/preferences/ServiceDetailsScreen.tsx
+++ b/ts/screens/preferences/ServiceDetailsScreen.tsx
@@ -330,7 +330,7 @@ class ServiceDetailsScreen extends React.Component<Props, State> {
             </Row>
             <View spacer={true} large={true} />
             {description && (
-              <Markdown lazy={true} animated={true}>
+              <Markdown lazyOptions={{ lazy: true, animated: true }}>
                 {description}
               </Markdown>
             )}


### PR DESCRIPTION
We can now insert internal link to selected screens using this format in markdown:

```
Go to [Profile](ioit://ROUTE_NAME)
```
I have tested and links of this type are already stripped down from the email version of the message

![inmessagelink](https://user-images.githubusercontent.com/30595520/44853070-3d01c280-ac65-11e8-9e4e-6e83c405bd23.gif)
