### PR TITLE
[#160195061] Add current route to overlay info

### DIFF
--- a/ts/components/VersionInfoOverlay.tsx
+++ b/ts/components/VersionInfoOverlay.tsx
@@ -1,6 +1,6 @@
 import { Text, View } from "native-base";
 import * as React from "react";
-import { StyleSheet } from "react-native";
+import { Platform, StyleSheet } from "react-native";
 import DeviceInfo from "react-native-device-info";
 import { NavigationState } from "react-navigation";
 import { connect } from "react-redux";
@@ -20,7 +20,10 @@ type Props = ReduxMappedProps & ReduxProps;
 const styles = StyleSheet.create({
   versionContainer: {
     position: "absolute",
-    top: 0,
+    top: Platform.select({
+      ios: 20,
+      android: 0
+    }),
     left: 0,
     right: 0,
     bottom: 0,

--- a/ts/components/VersionInfoOverlay.tsx
+++ b/ts/components/VersionInfoOverlay.tsx
@@ -1,16 +1,17 @@
-import * as React from "react";
-
-import DeviceInfo from "react-native-device-info";
-
 import { Text, View } from "native-base";
+import * as React from "react";
 import { StyleSheet } from "react-native";
+import DeviceInfo from "react-native-device-info";
+import { NavigationState } from "react-navigation";
 import { connect } from "react-redux";
 
 import { ServerInfo } from "../../definitions/backend/ServerInfo";
+import { getCurrentRouteName } from "../middlewares/analytics";
 import { ReduxProps } from "../store/actions/types";
 import { GlobalState } from "../store/reducers/types";
 
 interface ReduxMappedProps {
+  nav: NavigationState;
   serverInfo: ServerInfo | undefined;
 }
 
@@ -30,6 +31,12 @@ const styles = StyleSheet.create({
 
   versionText: {
     fontSize: 12,
+    lineHeight: 14,
+    color: "#000000"
+  },
+
+  routeText: {
+    fontSize: 10,
     lineHeight: 12,
     color: "#000000"
   }
@@ -41,13 +48,16 @@ const VersionInfoOverlay: React.SFC<Props> = props => {
   const serverVersion = serverInfo ? serverInfo.version : "?";
   return (
     <View style={styles.versionContainer} pointerEvents="box-none">
-      <Text style={styles.versionText}>{appVersion}</Text>
-      <Text style={styles.versionText}>{serverVersion}</Text>
+      <Text style={styles.versionText}>
+        {appVersion} - {serverVersion}
+      </Text>
+      <Text style={styles.routeText}>{getCurrentRouteName(props.nav)}</Text>
     </View>
   );
 };
 
 const mapStateToProps = (state: GlobalState): ReduxMappedProps => ({
+  nav: state.nav,
   serverInfo: state.backendInfo.serverInfo
 });
 

--- a/ts/middlewares/analytics.ts
+++ b/ts/middlewares/analytics.ts
@@ -123,12 +123,20 @@ export function getCurrentRouteName(navNode: any): string | undefined {
     return undefined;
   }
 
-  if (navNode.routeName && typeof navNode.routeName === "string") {
+  if (
+    navNode.index === undefined &&
+    navNode.routeName &&
+    typeof navNode.routeName === "string"
+  ) {
     // navNode is a NavigationLeafRoute
     return navNode.routeName;
   }
 
-  if (navNode.routes && navNode.index && navNode.routes[navNode.index]) {
+  if (
+    navNode.routes &&
+    navNode.index !== undefined &&
+    navNode.routes[navNode.index]
+  ) {
     const route = navNode.routes[navNode.index];
     return getCurrentRouteName(route);
   }


### PR DESCRIPTION
This also fix a problem in the getCurrentRouteName function that was not returning the deepest route

![route_name](https://user-images.githubusercontent.com/30595520/44912542-dba42700-ad2a-11e8-98c8-e95c2c66f48b.png)
