### PR TITLE
[#160200963] [WIP] change "cancel" behavior for "manual entry" screen

### DIFF
--- a/ts/screens/wallet/payment/ManualDataInsertionScreen.tsx
+++ b/ts/screens/wallet/payment/ManualDataInsertionScreen.tsx
@@ -37,7 +37,6 @@ import AppHeader from "../../../components/ui/AppHeader";
 
 import FooterWithButtons from "../../../components/ui/FooterWithButtons";
 import I18n from "../../../i18n";
-import ROUTES from "../../../navigation/routes";
 
 import { Dispatch } from "../../../store/actions/types";
 import {
@@ -130,7 +129,7 @@ class ManualDataInsertionScreen extends React.Component<Props, State> {
       block: true,
       light: true,
       bordered: true,
-      onPress: () => this.props.navigation.navigate(ROUTES.WALLET_HOME),
+      onPress: () => this.props.goBack(),
       title: I18n.t("global.buttons.cancel")
     };
 


### PR DESCRIPTION
When pressing the "cancel" button in the "enter data manually" screen of the payment process, the app was taken back to the home screen, without resetting the payment state. Then, if the user tries to get back into the payment process, the previous payment will result as still ongoing, and will thus not let the user continue. 

I have now fixed the "cancel" button behavior to return back to the QR code screen, thus fixing the problem. 

@matteodesanti you probably already mentioned it, but what is the expected behavior when pressing the "cancel" button in:
- the "enter data manually" screen: going back to the home screen, or return to the "scan qr code" screen?
- the initial "payment summary" screen (with the updated amount & payment info): going back to the "enter manually" or "scan qr code" screen, or back to the home screen?