### PR TITLE
[#160226908] Revert react-native-push-notification version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-native-mixpanel": "^0.0.16",
     "react-native-offline": "3.11.0",
     "react-native-popup-menu": "^0.14.0",
-    "react-native-push-notification": "^3.0.2",
+    "react-native-push-notification": "3.0.2",
     "react-native-qrcode-scanner": "^1.0.1",
     "react-native-sha256": "^1.0.1",
     "react-native-splash-screen": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6322,9 +6322,9 @@ react-native-popup-menu@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/react-native-popup-menu/-/react-native-popup-menu-0.14.0.tgz#8a11e4a78f76f5883fa5eb9d736f0ec2df8765ce"
 
-react-native-push-notification@^3.0.2:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/react-native-push-notification/-/react-native-push-notification-3.1.1.tgz#99ce426e78e95788c298f73750cc4e68db04d7ab"
+react-native-push-notification@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/react-native-push-notification/-/react-native-push-notification-3.0.2.tgz#3fa7d654cfd915436597b0dd5ba8b0f898c4b0f5"
 
 react-native-qrcode-scanner@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
The new version of react-native-push-notification switchs from GCM to Firebase. There is a PR for re-adding the old GCM listener https://github.com/zo0r/react-native-push-notification/pull/835. We need to investigate if the Azure NH fully support Firebase and than upgrade this library.