### PR TITLE
[#158788201] Navigate to IDP selection screen when session expires.

### DIFF
--- a/ts/sagas/startup/__tests__/authenticationSaga.test.ts
+++ b/ts/sagas/startup/__tests__/authenticationSaga.test.ts
@@ -7,9 +7,12 @@ import {
 import { loginSuccess } from "../../../store/actions/authentication";
 import { LOGIN_SUCCESS } from "../../../store/actions/constants";
 import { resetToAuthenticationRoute } from "../../../store/actions/navigation";
+import { isSessionExpiredSelector } from "../../../store/reducers/authentication";
 
 import { SessionToken } from "../../../types/SessionToken";
 
+import { NavigationActions } from "react-navigation";
+import ROUTES from "../../../navigation/routes";
 import { authenticationSaga } from "../authenticationSaga";
 
 const aSessionToken = "a_session_token" as SessionToken;
@@ -20,7 +23,29 @@ describe("authenticationSaga", () => {
       .next()
       .put(analyticsAuthenticationStarted)
       .next()
+      .select(isSessionExpiredSelector)
+      .next(false)
       .put(resetToAuthenticationRoute)
+      .next()
+      .take(LOGIN_SUCCESS)
+      .next(loginSuccess(aSessionToken))
+      .put(analyticsAuthenticationCompleted)
+      .next()
+      .returns(aSessionToken);
+  });
+
+  it("should navigate to IDP selection screen on session expired and return the session token on login success", () => {
+    testSaga(authenticationSaga)
+      .next()
+      .put(analyticsAuthenticationStarted)
+      .next()
+      .select(isSessionExpiredSelector)
+      .next(true)
+      .put(
+        NavigationActions.navigate({
+          routeName: ROUTES.AUTHENTICATION_IDP_SELECTION
+        })
+      )
       .next()
       .take(LOGIN_SUCCESS)
       .next(loginSuccess(aSessionToken))

--- a/ts/screens/authentication/IdpSelectionScreen.tsx
+++ b/ts/screens/authentication/IdpSelectionScreen.tsx
@@ -19,7 +19,7 @@ import ROUTES from "../../navigation/routes";
 import { idpSelected } from "../../store/actions/authentication";
 import { ReduxProps } from "../../store/actions/types";
 
-import { isLoggedIn } from "../../store/reducers/authentication";
+import { isSessionExpiredSelector } from "../../store/reducers/authentication";
 import { GlobalState } from "../../store/reducers/types";
 
 import variables from "../../theme/variables";
@@ -169,9 +169,8 @@ const IdpSelectionScreen: React.SFC<Props> = props => {
   );
 };
 
-const mapStateToProps = ({ authentication }: GlobalState) => ({
-  isSessionExpired:
-    !isLoggedIn(authentication) && authentication.reason === "SESSION_EXPIRED"
+const mapStateToProps = (state: GlobalState) => ({
+  isSessionExpired: isSessionExpiredSelector(state)
 });
 
 export default connect(mapStateToProps)(IdpSelectionScreen);

--- a/ts/store/reducers/authentication.ts
+++ b/ts/store/reducers/authentication.ts
@@ -97,6 +97,9 @@ export function isLoggedIn(
   );
 }
 
+export const isSessionExpiredSelector = ({ authentication }: GlobalState) =>
+  !isLoggedIn(authentication) && authentication.reason === "SESSION_EXPIRED";
+
 // Selectors
 
 export const isLoggedInSelector = (state: GlobalState): boolean =>


### PR DESCRIPTION
![session-expired](https://user-images.githubusercontent.com/11299464/45364085-86450100-b5d9-11e8-924a-53edda61b123.gif)

@matteodesanti With this behaviour, should the IDP selection screen have the _back to home_ button?