### PR TITLE
Little refactoring of fetch and long timeout fetch

### DIFF
--- a/ts/config.ts
+++ b/ts/config.ts
@@ -18,6 +18,9 @@ const DEFAULT_FETCH_TIMEOUT_MS = 3000;
 // default max retries for fetch
 const DEFAULT_FETCH_MAX_RETRIES = 3;
 
+// default timeout of fetch for calling the PagoPA SOAP APIs
+const DEFAULT_FETCH_PAGOPA_TIMEOUT_MS = 15000;
+
 // default seconds of background activity before asking the PIN login
 const DEFAULT_BACKGROUND_ACTIVITY_TIMEOUT_S = 30;
 
@@ -37,6 +40,10 @@ export const fetchTimeout = t.Integer.decode(Config.FETCH_TIMEOUT_MS).getOrElse(
 export const fetchMaxRetries = t.Integer.decode(
   Config.FETCH_MAX_RETRIES
 ).getOrElse(DEFAULT_FETCH_MAX_RETRIES);
+
+export const fetchPagoPaTimeout = t.Integer.decode(
+  Config.FETCH_PAGOPA_TIMEOUT_MS
+).getOrElse(DEFAULT_FETCH_PAGOPA_TIMEOUT_MS) as Millisecond;
 
 export const backgroundActivityTimeout = t.Integer.decode(
   Config.BACKGROUND_ACTIVITY_TIMEOUT_S

--- a/ts/sagas/wallet.ts
+++ b/ts/sagas/wallet.ts
@@ -122,7 +122,7 @@ import {
 } from "../types/pagopa";
 import { SessionToken } from "../types/SessionToken";
 import { amountToImportoWithFallback } from "../utils/amounts";
-import { constantPollingFetch } from "../utils/fetch";
+import { constantPollingFetch, pagopaFetch } from "../utils/fetch";
 
 // allow refreshing token this number of times
 const MAX_TOKEN_REFRESHES = 2;
@@ -464,7 +464,11 @@ function* showTransactionSummaryHandler(
       sessionTokenSelector
     );
     if (sessionToken) {
-      const backendClient = BackendClient(apiUrlPrefix, sessionToken);
+      const backendClient = BackendClient(
+        apiUrlPrefix,
+        sessionToken,
+        pagopaFetch()
+      );
       const response:
         | BasicResponseTypeWith401<PaymentRequestsGetResponse>
         | undefined = yield call(backendClient.getVerificaRpt, { rptId });
@@ -600,7 +604,11 @@ const attivaRpt = async (
   paymentContextCode: CodiceContestoPagamento,
   amount: AmountInEuroCents
 ): Promise<boolean> => {
-  const backendClient = BackendClient(apiUrlPrefix, sessionToken);
+  const backendClient = BackendClient(
+    apiUrlPrefix,
+    sessionToken,
+    pagopaFetch()
+  );
 
   const response:
     | BasicResponseTypeWith401<PaymentActivationsPostResponse>


### PR DESCRIPTION
This PR introduces an implementation of `fetch` with long timeout, suitable for calling verifica/attiva