### PR TITLE
Pass sessiontoken to the wallet saga

### DIFF
--- a/ts/api/backend.ts
+++ b/ts/api/backend.ts
@@ -145,7 +145,7 @@ export type LogoutT = IPostApiRequestType<
   BasicResponseTypeWith401<SuccessResponse>
 >;
 
-type VerificaRptT = IGetApiRequestType<
+export type VerificaRptT = IGetApiRequestType<
   {
     rptId: RptId;
   },
@@ -154,7 +154,7 @@ type VerificaRptT = IGetApiRequestType<
   BasicResponseTypeWith401<PaymentRequestsGetResponse>
 >;
 
-type AttivaRptT = IPostApiRequestType<
+export type AttivaRptT = IPostApiRequestType<
   {
     rptId: string;
     paymentContextCode: CodiceContestoPagamento;
@@ -165,7 +165,7 @@ type AttivaRptT = IPostApiRequestType<
   BasicResponseTypeWith401<PaymentActivationsPostResponse>
 >;
 
-type GetPaymentIdT = IGetApiRequestType<
+export type GetPaymentIdT = IGetApiRequestType<
   {
     paymentContextCode: CodiceContestoPagamento;
   },

--- a/ts/sagas/index.ts
+++ b/ts/sagas/index.ts
@@ -8,7 +8,6 @@ import backendInfoSaga from "./backendInfo";
 import { watchContentServiceLoadSaga } from "./contentLoaders";
 import { loadSystemPreferencesSaga } from "./preferences";
 import { startupSaga } from "./startup";
-import walletSaga from "./wallet";
 import { watchNavigateToDeepLinkSaga } from "./watchNavigateToDeepLinkSaga";
 
 import { apiUrlPrefix } from "../config";
@@ -27,7 +26,6 @@ const connectionMonitorParameters = {
 export default function* root(): Iterator<Effect> {
   yield all([
     call(startupSaga),
-    call(walletSaga), // FIXME: move to startup: the wallet token gets fetched there
     call(backendInfoSaga),
     call(networkEventsListenerSaga, connectionMonitorParameters),
     call(watchNavigateToDeepLinkSaga),

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -145,7 +145,7 @@ function* initializeApplicationSaga(): IterableIterator<Effect> {
     pagoPaApiUrlPrefix,
     maybeSessionInformation.value.walletToken
   );
-  yield fork(watchWalletSaga, pagoPaClient);
+  yield fork(watchWalletSaga, sessionToken, pagoPaClient);
 
   // Start watching for profile update requests as the checkProfileEnabledSaga
   // may need to update the profile.


### PR DESCRIPTION
Make the wallet saga receive the session token from the startup saga and create the backend client(s) once, instead of having child-sagas create their own clients hand having to check the presence of a valid session token