### PR TITLE
setting underlineColorAndroid to "transparent"

### DIFF
--- a/ts/components/LabelledItem.tsx
+++ b/ts/components/LabelledItem.tsx
@@ -66,6 +66,7 @@ export class LabelledItem extends React.Component<Props> {
               placeholder={this.props.placeholder}
               mask={this.props.mask}
               onChangeText={this.props.onChangeText}
+              underlineColorAndroid="transparent"
               {...this.props.inputProps}
             />
           ) : (
@@ -75,6 +76,7 @@ export class LabelledItem extends React.Component<Props> {
                 .string()}
               placeholder={this.props.placeholder}
               onChangeText={this.props.onChangeText}
+              underlineColorAndroid="transparent"
               {...this.props.inputProps}
             />
           )}


### PR DESCRIPTION
As per [this discussion](https://developersitalia.slack.com/archives/CA70BM37X/p1537277944000100) (video documenting the problem [here](https://developersitalia.slack.com/files/U75H1BEHF/FCWSM7K0X/bug_inserimento_carta_1.0.1_-_0.0.56.mov))

New behavior on Android
<img src="https://user-images.githubusercontent.com/107715/45695711-498d8280-bb62-11e8-8b6f-581205fc357c.png" width="256"/>
