### PR TITLE
[#160708519] adding shadows and perspective on iOS

### DIFF
--- a/ts/components/wallet/WalletLayout.tsx
+++ b/ts/components/wallet/WalletLayout.tsx
@@ -42,15 +42,22 @@ const styles = StyleSheet.create({
   },
   firstCard: {
     flex: 1,
-    transform: [{ rotateX: "-20deg" }, { scaleX: 0.98 }]
+    shadowRadius: 10,
+    shadowOpacity: 0.15,
+    transform: [{ perspective: 700 }, { rotateX: "-20deg" }, { scaleX: 0.98 }],
+    zIndex: -10
   },
   secondCard: {
     flex: 1,
+    shadowRadius: 10,
+    shadowOpacity: 0.15,
     transform: [
+      { perspective: 700 },
       { rotateX: "-20deg" },
       { translateY: -(58 / 2 + 20) * (1 - Math.cos(20)) },
       { scaleX: 0.98 }
-    ]
+    ],
+    zIndex: -10
   },
   shiftDown: {
     marginBottom: -(58 / 2 + 1)

--- a/ts/components/wallet/card/index.tsx
+++ b/ts/components/wallet/card/index.tsx
@@ -64,7 +64,9 @@ const styles = StyleSheet.create({
     borderBottomRightRadius: 0
   },
   rotatedCard: {
-    transform: [{ rotateX: "-20deg" }, { scaleX: 0.98 }],
+    shadowRadius: 10,
+    shadowOpacity: 0.15,
+    transform: [{ perspective: 700 }, { rotateX: "-20deg" }, { scaleX: 0.98 }],
     marginBottom: -3
   },
   blueText: {


### PR DESCRIPTION
iOS requires a perspective to be defined in order to render rotations properly. 

Some shadows were also added to make things look better (and resemble the invision more closely). Unfortunately, on Android, shadows don't work quite as well (they do not rotate with the components), so they would look particularly bad. For now, they have been omitted.

**iOS**
<img src="https://user-images.githubusercontent.com/107715/45926833-5d056880-bf29-11e8-8d34-ba418624c7f0.png" width = "256" />

**Android**
<img src="https://user-images.githubusercontent.com/107715/45926834-5e369580-bf29-11e8-9013-1b10224c5449.png" width = "256" />
