### PR TITLE
[#160648909] Show relevant screen when the user has no wallets

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -229,8 +229,7 @@ wallet:
     failed: The card could not be deleted
   newPaymentMethod:
     add: add
-    addButton: Add payment method
-    newMethod: Choose another payment method
+    addButton: Add a new card
     addDescription: You can add your payment methods (e.g. credit cards, bank accounts)
       so that you don't have to re-add them from scratch for every transaction
     successful: The card was added successfully!
@@ -270,9 +269,12 @@ wallet:
     changeMethod: Change the payment method
     change: Change method
   payWith:
+    noWallets:
+      title: No card found
+      text: Add a new card to proceed with the payment
     header: Choose payment method
     title: Pay with
-    info: Choose one saved payment method or add a new one
+    text: Choose one saved payment method or add a new one
   firstTransactionSummary:
     header: Transaction notice summary
     title: Transaction notice

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -236,8 +236,7 @@ wallet:
     failed: Impossibile cancellare la carta
   newPaymentMethod:
     add: aggiungi
-    addButton: Aggiungi un metodo di pagamento
-    newMethod: Scegli un altro metodo di pagamento
+    addButton: Aggiungi una carta
     addDescription: Puoi aggiungere i tuoi metodi di pagamento (carte, conti correnti,
       ecc.) per non doverli inserire ad ogni transazione
     successful: Carta aggiunta con successo
@@ -280,9 +279,12 @@ wallet:
     changeMethod: Cambia metodo di pagamento
     change: Cambia metodo
   payWith:
+    noWallets:
+      title: Nessuna carta salvata
+      text: Aggiungi una carta per procedere con il pagamento
     header: Scelta metodo di pagamamento
     title: Paga con
-    info: Scegli fra i metodi salvati o aggiungi un nuovo metodo di pagamento
+    text: Scegli fra i metodi salvati o aggiungi un nuovo metodo di pagamento
   firstTransactionSummary:
     header: Riepilogo avviso di Pagamento
     title: Avviso di pagamento

--- a/ts/components/styles/wallet.ts
+++ b/ts/components/styles/wallet.ts
@@ -53,6 +53,13 @@ export const WalletStyles = StyleSheet.create({
     backgroundColor: variables.colorWhite,
     flex: 1
   },
+  padded: {
+    padding: variables.contentPadding
+  },
+  noBottomPadding: {
+    padding: variables.contentPadding,
+    paddingBottom: 0
+  },
   pfImage: {
     height: "100%",
     width: "100%",

--- a/ts/components/wallet/TransactionsList.tsx
+++ b/ts/components/wallet/TransactionsList.tsx
@@ -120,7 +120,10 @@ class TransactionsList extends React.Component<Props> {
 
     if (transactions.length === 0) {
       return (
-        <Content scrollEnabled={false} style={WalletStyles.whiteContent}>
+        <Content
+          scrollEnabled={false}
+          style={[WalletStyles.noBottomPadding, WalletStyles.whiteContent]}
+        >
           <View spacer={true} />
           <H3>{I18n.t("wallet.noneTransactions")}</H3>
           <View spacer={true} />
@@ -131,7 +134,10 @@ class TransactionsList extends React.Component<Props> {
     }
     // TODO: onPress should redirect to the transaction details @https://www.pivotaltracker.com/story/show/154442946
     return (
-      <Content scrollEnabled={false} style={WalletStyles.whiteContent}>
+      <Content
+        scrollEnabled={false}
+        style={[WalletStyles.noBottomPadding, WalletStyles.whiteContent]}
+      >
         <Grid>
           <Row>
             <Left>

--- a/ts/components/wallet/WalletLayout.tsx
+++ b/ts/components/wallet/WalletLayout.tsx
@@ -37,9 +37,6 @@ const styles = StyleSheet.create({
   darkGrayBg: {
     backgroundColor: variables.brandDarkGray
   },
-  noBottomPadding: {
-    paddingBottom: 0
-  },
   firstCard: {
     flex: 1,
     transform: [{ rotateX: "-20deg" }, { scaleX: 0.98 }]
@@ -204,7 +201,7 @@ class WalletLayout extends React.Component<Props> {
         <ScrollView bounces={false} style={WalletStyles.whiteBg}>
           <Content
             scrollEnabled={false}
-            style={[styles.darkGrayBg, styles.noBottomPadding]}
+            style={[styles.darkGrayBg, WalletStyles.noBottomPadding]}
           >
             {this.props.headerContents}
             {this.getLogo()}

--- a/ts/screens/wallet/TransactionDetailsScreen.tsx
+++ b/ts/screens/wallet/TransactionDetailsScreen.tsx
@@ -141,7 +141,10 @@ class TransactionDetailsScreen extends React.Component<Props> {
         showPayButton={false}
         allowGoBack={!paymentCompleted}
       >
-        <Content scrollEnabled={false} style={WalletStyles.whiteContent}>
+        <Content
+          scrollEnabled={false}
+          style={[WalletStyles.noBottomPadding, WalletStyles.whiteContent]}
+        >
           <Grid>
             <Row style={styles.titleRow}>
               <H3>{I18n.t("wallet.transactionDetails")}</H3>

--- a/ts/screens/wallet/WalletsScreen.tsx
+++ b/ts/screens/wallet/WalletsScreen.tsx
@@ -46,7 +46,7 @@ class WalletsScreen extends React.Component<Props, never> {
         navigation={this.props.navigation}
         headerContents={headerContents}
       >
-        <Content style={WalletStyles.header}>
+        <Content style={[WalletStyles.padded, WalletStyles.header]}>
           <List
             removeClippedSubviews={false}
             dataArray={this.props.wallets as any[]} // tslint:disable-line

--- a/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
@@ -73,7 +73,7 @@ class PickPaymentMethodScreen extends React.Component<Props> {
       block: true,
       onPress: () =>
         this.props.navigation.navigate(ROUTES.WALLET_ADD_PAYMENT_METHOD),
-      title: I18n.t("wallet.newPaymentMethod.newMethod")
+      title: I18n.t("wallet.newPaymentMethod.addButton")
     };
 
     const secondaryButtonProps = {
@@ -82,6 +82,8 @@ class PickPaymentMethodScreen extends React.Component<Props> {
       onPress: this.props.showSummary,
       title: I18n.t("global.buttons.cancel")
     };
+
+    const { wallets } = this.props;
 
     return (
       <Container>
@@ -98,13 +100,25 @@ class PickPaymentMethodScreen extends React.Component<Props> {
 
           <View style={WalletStyles.paddedLR}>
             <View spacer={true} />
-            <H1> {I18n.t("wallet.payWith.title")} </H1>
+            <H1>
+              {I18n.t(
+                wallets.length > 0
+                  ? "wallet.payWith.title"
+                  : "wallet.payWith.noWallets.title"
+              )}
+            </H1>
             <View spacer={true} />
-            <Text> {I18n.t("wallet.payWith.info")}</Text>
+            <Text>
+              {I18n.t(
+                wallets.length > 0
+                  ? "wallet.payWith.text"
+                  : "wallet.payWith.noWallets.text"
+              )}
+            </Text>
             <View spacer={true} />
             <List
               removeClippedSubviews={false}
-              dataArray={this.props.wallets as any[]} // tslint:disable-line: readonly-array
+              dataArray={wallets as any[]} // tslint:disable-line: readonly-array
               renderRow={(item): React.ReactElement<any> => (
                 <CardComponent
                   navigation={this.props.navigation}


### PR DESCRIPTION
During the payment process, if no wallets are available, the user is shown a message asking to select among the available methods (though there are none). Now, in that case, the message states that there are no cards stored and that the user should proceed with adding a new one. 