### PR TITLE
Show loading summary screen

### DIFF
--- a/ts/components/wallet/PaymentSummaryComponent.tsx
+++ b/ts/components/wallet/PaymentSummaryComponent.tsx
@@ -1,40 +1,39 @@
 /**
  * This component will display the transaction details if updates on the amount are identified
  */
+import {
+  AmountInEuroCents,
+  AmountInEuroCentsFromNumber
+} from "italia-ts-commons/lib/pagopa";
 import { H1, H3, Icon, Text, View } from "native-base";
 import * as React from "react";
 import { Image, Platform, StyleSheet } from "react-native";
 import { Col, Grid, Row } from "react-native-easy-grid";
 import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { connect } from "react-redux";
 import { WalletStyles } from "../../components/styles/wallet";
 import I18n from "../../i18n";
-import variables from "../../theme/variables";
-import { buildAmount } from "../../utils/stringBuilder";
-import { GlobalState } from '../../store/reducers/types';
+import { GlobalState } from "../../store/reducers/types";
 import {
   getCurrentAmount,
   getInitialAmount,
   getPaymentReason,
   isGlobalStateWithVerificaResponse
 } from "../../store/reducers/wallet/payment";
-import {
-  UNKNOWN_PAYMENT_REASON
-} from "../../types/unknown";
-import {
-  AmountInEuroCents,
-  AmountInEuroCentsFromNumber
-} from "italia-ts-commons/lib/pagopa";
-import { connect } from 'react-redux';
+import variables from "../../theme/variables";
+import { UNKNOWN_PAYMENT_REASON } from "../../types/unknown";
+import { buildAmount } from "../../utils/stringBuilder";
 
-
-type ReduxMappedStateProps = Readonly<{
-  amount: AmountInEuroCents;
-  updatedAmount: AmountInEuroCents;
-  paymentReason: string;
-  hasVerificaResponse: true;
-}> | Readonly<{
-  hasVerificaResponse: false;
-}>;
+type ReduxMappedStateProps =
+  | Readonly<{
+      amount: AmountInEuroCents;
+      updatedAmount: AmountInEuroCents;
+      paymentReason: string;
+      hasVerificaResponse: true;
+    }>
+  | Readonly<{
+      hasVerificaResponse: false;
+    }>;
 
 type OwnProps = Readonly<{
   navigation: NavigationScreenProp<NavigationState>;
@@ -91,7 +90,6 @@ const styles = StyleSheet.create({
 });
 
 class PaymentSummaryComponent extends React.Component<Props> {
-
   private labelValueRow(label: React.ReactNode, value: React.ReactNode) {
     return (
       <Row style={WalletStyles.alignCenter}>
@@ -106,10 +104,18 @@ class PaymentSummaryComponent extends React.Component<Props> {
   }
 
   public render(): React.ReactNode {
-    const amount = this.props.hasVerificaResponse ? AmountInEuroCentsFromNumber.encode(this.props.amount) : undefined;
-    const updatedAmount = this.props.hasVerificaResponse ? AmountInEuroCentsFromNumber.encode(this.props.updatedAmount) : undefined;
-    const paymentReason = this.props.hasVerificaResponse ? this.props.paymentReason : undefined;
-    const amountIsUpdated = this.props.hasVerificaResponse && this.props.amount !== this.props.updatedAmount;
+    const amount = this.props.hasVerificaResponse
+      ? AmountInEuroCentsFromNumber.encode(this.props.amount)
+      : undefined;
+    const updatedAmount = this.props.hasVerificaResponse
+      ? AmountInEuroCentsFromNumber.encode(this.props.updatedAmount)
+      : undefined;
+    const paymentReason = this.props.hasVerificaResponse
+      ? this.props.paymentReason
+      : undefined;
+    const amountIsUpdated =
+      this.props.hasVerificaResponse &&
+      this.props.amount !== this.props.updatedAmount;
     return (
       <Grid style={[WalletStyles.header, styles.padded]}>
         <View spacer={true} large={true} />
@@ -118,7 +124,9 @@ class PaymentSummaryComponent extends React.Component<Props> {
             <H3 style={WalletStyles.white}>
               {I18n.t("wallet.firstTransactionSummary.title")}
             </H3>
-            <H1 style={WalletStyles.white}>{paymentReason !== undefined ? paymentReason : "..." }</H1>
+            <H1 style={WalletStyles.white}>
+              {paymentReason !== undefined ? paymentReason : "..."}
+            </H1>
           </Col>
           <Col
             size={1}
@@ -140,7 +148,9 @@ class PaymentSummaryComponent extends React.Component<Props> {
               {amount !== undefined ? buildAmount(amount) : "..."}
             </H3>
           ) : (
-            <H1 style={WalletStyles.white}>{amount !== undefined ? buildAmount(amount) : "..."}</H1>
+            <H1 style={WalletStyles.white}>
+              {amount !== undefined ? buildAmount(amount) : "..."}
+            </H1>
           )
         )}
         {amountIsUpdated && (
@@ -157,7 +167,9 @@ class PaymentSummaryComponent extends React.Component<Props> {
                 />
               </View>,
               <H1 style={WalletStyles.white}>
-                {updatedAmount !== undefined ? buildAmount(updatedAmount) : "..." }
+                {updatedAmount !== undefined
+                  ? buildAmount(updatedAmount)
+                  : "..."}
               </H1>
             )}
             <Row style={styles.toAlignColumnstart}>
@@ -195,18 +207,16 @@ class PaymentSummaryComponent extends React.Component<Props> {
   }
 }
 
-const mapStateToProps = (state: GlobalState): ReduxMappedStateProps => 
-  isGlobalStateWithVerificaResponse(state) ? {
-    hasVerificaResponse: true,
-    amount: getInitialAmount(state),
-    updatedAmount: getCurrentAmount(state),
-    paymentReason: getPaymentReason(state).getOrElse(
-      UNKNOWN_PAYMENT_REASON
-    )    
-  } : 
-  {
-    hasVerificaResponse: false
-  }
-;
+const mapStateToProps = (state: GlobalState): ReduxMappedStateProps =>
+  isGlobalStateWithVerificaResponse(state)
+    ? {
+        hasVerificaResponse: true,
+        amount: getInitialAmount(state),
+        updatedAmount: getCurrentAmount(state),
+        paymentReason: getPaymentReason(state).getOrElse(UNKNOWN_PAYMENT_REASON)
+      }
+    : {
+        hasVerificaResponse: false
+      };
 
 export default connect(mapStateToProps)(PaymentSummaryComponent);

--- a/ts/sagas/wallet.ts
+++ b/ts/sagas/wallet.ts
@@ -588,6 +588,10 @@ function* showTransactionSummaryHandler(
     // payload and proceed with showing the
     // transaction information fetched from the
     // pagoPA proxy
+
+    // First, navigate to the summary screen
+    yield put(navigateTo(ROUTES.PAYMENT_TRANSACTION_SUMMARY));
+
     const {
       rptId,
       initialAmount
@@ -617,10 +621,10 @@ function* showTransactionSummaryHandler(
       yield put(paymentResetLoadingState());
     }
   } else {
+    // also, show summary screen
     yield put(paymentTransactionSummaryFromBanner());
+    yield put(navigateTo(ROUTES.PAYMENT_TRANSACTION_SUMMARY));
   }
-  // also, show summary screen
-  yield put(navigateTo(ROUTES.PAYMENT_TRANSACTION_SUMMARY));
 }
 
 function* showConfirmPaymentMethod(

--- a/ts/screens/wallet/payment/ManualDataInsertionScreen.tsx
+++ b/ts/screens/wallet/payment/ManualDataInsertionScreen.tsx
@@ -35,7 +35,6 @@ import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
 import { RptIdFromString } from "../../../../definitions/backend/RptIdFromString";
 
-import { withLoadingSpinner } from "../../../components/helpers/withLoadingSpinner";
 import { InstabugButtons } from "../../../components/InstabugButtons";
 import AppHeader from "../../../components/ui/AppHeader";
 import FooterWithButtons from "../../../components/ui/FooterWithButtons";
@@ -46,7 +45,6 @@ import {
   paymentRequestGoBack,
   paymentRequestTransactionSummaryFromRptId
 } from "../../../store/actions/wallet/payment";
-import { createLoadingSelector } from "../../../store/reducers/loading";
 import { GlobalState } from "../../../store/reducers/types";
 import { getPaymentStep } from "../../../store/reducers/wallet/payment";
 
@@ -224,11 +222,7 @@ const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedDispatchProps => ({
   cancelPayment: () => dispatch(paymentRequestCancel())
 });
 
-export default withLoadingSpinner(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(ManualDataInsertionScreen),
-  createLoadingSelector(["PAYMENT_LOAD"]),
-  {}
-);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ManualDataInsertionScreen);

--- a/ts/screens/wallet/payment/ScanQrCodeScreen.tsx
+++ b/ts/screens/wallet/payment/ScanQrCodeScreen.tsx
@@ -20,7 +20,6 @@ import { Dimensions, ScrollView, StyleSheet } from "react-native";
 import QRCodeScanner from "react-native-qrcode-scanner";
 import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
-import { withLoadingSpinner } from "../../../components/helpers/withLoadingSpinner";
 import { InstabugButtons } from "../../../components/InstabugButtons";
 import AppHeader from "../../../components/ui/AppHeader";
 import FooterWithButtons from "../../../components/ui/FooterWithButtons";
@@ -31,7 +30,6 @@ import {
   paymentRequestManualEntry,
   paymentRequestTransactionSummaryFromRptId
 } from "../../../store/actions/wallet/payment";
-import { createLoadingSelector } from "../../../store/reducers/loading";
 import { GlobalState } from "../../../store/reducers/types";
 import { getPaymentStep } from "../../../store/reducers/wallet/payment";
 import variables from "../../../theme/variables";
@@ -240,11 +238,7 @@ const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedDispatchProps => ({
   goBack: () => dispatch(paymentRequestGoBack())
 });
 
-export default withLoadingSpinner(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(ScanQrCodeScreen),
-  createLoadingSelector(["PAYMENT_LOAD"]),
-  {}
-);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ScanQrCodeScreen);

--- a/ts/screens/wallet/payment/TransactionSummaryScreen.tsx
+++ b/ts/screens/wallet/payment/TransactionSummaryScreen.tsx
@@ -50,9 +50,9 @@ type ReduxMappedStateProps =
     }>
   | Readonly<{
       valid: true;
-      paymentReason: string;
-      paymentRecipient: EnteBeneficiario;
-      rptId: RptId;
+      paymentReason: string | undefined;
+      paymentRecipient: EnteBeneficiario | undefined;
+      rptId: RptId | undefined;
     }>;
 
 type ReduxMappedDispatchProps = Readonly<{
@@ -112,6 +112,8 @@ class TransactionSummaryScreen extends React.Component<Props, never> {
       title: I18n.t("wallet.cancel")
     };
 
+    const { paymentRecipient, paymentReason, rptId } = this.props;
+
     return (
       <Container>
         <AppHeader>
@@ -132,14 +134,14 @@ class TransactionSummaryScreen extends React.Component<Props, never> {
           />
           <View content={true}>
             <Markdown>
-              {formatMdRecipient(this.props.paymentRecipient)}
+              { paymentRecipient !== undefined ? formatMdRecipient(paymentRecipient) : "..." }
             </Markdown>
             <View spacer={true} />
             <Markdown>
-              {formatMdPaymentReason(this.props.paymentReason)}
+              { paymentReason !== undefined ? formatMdPaymentReason(paymentReason) : "..." }
             </Markdown>
             <View spacer={true} />
-            <Markdown>{formatMdInfoRpt(this.props.rptId)}</Markdown>
+            <Markdown>{ rptId !== undefined ? formatMdInfoRpt(rptId) : "..." }</Markdown>
             <View spacer={true} />
           </View>
         </Content>
@@ -167,6 +169,13 @@ const mapStateToProps = (state: GlobalState): ReduxMappedStateProps =>
         ), // could be undefined as per pagoPA type definition
         rptId: getRptId(state)
       }
+    : (getPaymentStep(state) === "PaymentStateNoState" || getPaymentStep(state) === "PaymentStateQrCode" || getPaymentStep(state) === "PaymentStateManualEntry") ?
+    {
+      valid: true, 
+      paymentReason: undefined,
+      paymentRecipient: undefined,
+      rptId: undefined
+    }
     : { valid: false };
 
 const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedDispatchProps => ({

--- a/ts/screens/wallet/payment/TransactionSummaryScreen.tsx
+++ b/ts/screens/wallet/payment/TransactionSummaryScreen.tsx
@@ -129,19 +129,23 @@ class TransactionSummaryScreen extends React.Component<Props, never> {
         </AppHeader>
 
         <Content noPadded={true}>
-          <PaymentSummaryComponent
-            navigation={this.props.navigation}
-          />
+          <PaymentSummaryComponent navigation={this.props.navigation} />
           <View content={true}>
             <Markdown>
-              { paymentRecipient !== undefined ? formatMdRecipient(paymentRecipient) : "..." }
+              {paymentRecipient !== undefined
+                ? formatMdRecipient(paymentRecipient)
+                : "..."}
             </Markdown>
             <View spacer={true} />
             <Markdown>
-              { paymentReason !== undefined ? formatMdPaymentReason(paymentReason) : "..." }
+              {paymentReason !== undefined
+                ? formatMdPaymentReason(paymentReason)
+                : "..."}
             </Markdown>
             <View spacer={true} />
-            <Markdown>{ rptId !== undefined ? formatMdInfoRpt(rptId) : "..." }</Markdown>
+            <Markdown>
+              {rptId !== undefined ? formatMdInfoRpt(rptId) : "..."}
+            </Markdown>
             <View spacer={true} />
           </View>
         </Content>
@@ -155,7 +159,7 @@ class TransactionSummaryScreen extends React.Component<Props, never> {
   }
 }
 
-const mapStateToProps = (state: GlobalState): ReduxMappedStateProps => 
+const mapStateToProps = (state: GlobalState): ReduxMappedStateProps =>
   (getPaymentStep(state) === "PaymentStateSummary" ||
     getPaymentStep(state) === "PaymentStateSummaryWithPaymentId") &&
   isGlobalStateWithVerificaResponse(state)
@@ -169,14 +173,16 @@ const mapStateToProps = (state: GlobalState): ReduxMappedStateProps =>
         ), // could be undefined as per pagoPA type definition
         rptId: getRptId(state)
       }
-    : (getPaymentStep(state) === "PaymentStateNoState" || getPaymentStep(state) === "PaymentStateQrCode" || getPaymentStep(state) === "PaymentStateManualEntry") ?
-    {
-      valid: true, 
-      paymentReason: undefined,
-      paymentRecipient: undefined,
-      rptId: undefined
-    }
-    : { valid: false };
+    : getPaymentStep(state) === "PaymentStateNoState" ||
+      getPaymentStep(state) === "PaymentStateQrCode" ||
+      getPaymentStep(state) === "PaymentStateManualEntry"
+      ? {
+          valid: true,
+          paymentReason: undefined,
+          paymentRecipient: undefined,
+          rptId: undefined
+        }
+      : { valid: false };
 
 const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedDispatchProps => ({
   confirmSummary: () => dispatch(paymentRequestContinueWithPaymentMethods()),

--- a/ts/screens/wallet/payment/TransactionSummaryScreen.tsx
+++ b/ts/screens/wallet/payment/TransactionSummaryScreen.tsx
@@ -8,8 +8,6 @@
  */
 
 import {
-  AmountInEuroCents,
-  AmountInEuroCentsFromNumber,
   PaymentNoticeNumberFromString,
   RptId
 } from "italia-ts-commons/lib/pagopa";
@@ -35,8 +33,6 @@ import {
 import { createLoadingSelector } from "../../../store/reducers/loading";
 import { GlobalState } from "../../../store/reducers/types";
 import {
-  getCurrentAmount,
-  getInitialAmount,
   getPaymentReason,
   getPaymentRecipient,
   getPaymentStep,
@@ -54,8 +50,6 @@ type ReduxMappedStateProps =
     }>
   | Readonly<{
       valid: true;
-      initialAmount: AmountInEuroCents;
-      currentAmount: AmountInEuroCents;
       paymentReason: string;
       paymentRecipient: EnteBeneficiario;
       rptId: RptId;
@@ -104,11 +98,6 @@ class TransactionSummaryScreen extends React.Component<Props, never> {
       return null;
     }
 
-    const amount = AmountInEuroCentsFromNumber.encode(this.props.initialAmount);
-    const updatedAmount = AmountInEuroCentsFromNumber.encode(
-      this.props.currentAmount
-    );
-
     const primaryButtonProps = {
       block: true,
       primary: true,
@@ -140,9 +129,6 @@ class TransactionSummaryScreen extends React.Component<Props, never> {
         <Content noPadded={true}>
           <PaymentSummaryComponent
             navigation={this.props.navigation}
-            amount={amount}
-            updatedAmount={updatedAmount}
-            paymentReason={this.props.paymentReason}
           />
           <View content={true}>
             <Markdown>
@@ -173,8 +159,6 @@ const mapStateToProps = (state: GlobalState): ReduxMappedStateProps =>
   isGlobalStateWithVerificaResponse(state)
     ? {
         valid: true,
-        initialAmount: getInitialAmount(state),
-        currentAmount: getCurrentAmount(state),
         paymentReason: getPaymentReason(state).getOrElse(
           UNKNOWN_PAYMENT_REASON
         ), // could be undefined as per pagoPA type definition

--- a/ts/screens/wallet/payment/TransactionSummaryScreen.tsx
+++ b/ts/screens/wallet/payment/TransactionSummaryScreen.tsx
@@ -155,7 +155,7 @@ class TransactionSummaryScreen extends React.Component<Props, never> {
   }
 }
 
-const mapStateToProps = (state: GlobalState): ReduxMappedStateProps =>
+const mapStateToProps = (state: GlobalState): ReduxMappedStateProps => 
   (getPaymentStep(state) === "PaymentStateSummary" ||
     getPaymentStep(state) === "PaymentStateSummaryWithPaymentId") &&
   isGlobalStateWithVerificaResponse(state)

--- a/ts/store/reducers/wallet/payment.ts
+++ b/ts/store/reducers/wallet/payment.ts
@@ -214,7 +214,7 @@ export const isGlobalStateWithSelectedPaymentMethod = (
 export const getPaymentStep = (state: GlobalState) =>
   state.wallet.payment.stack !== null
     ? state.wallet.payment.stack.head.kind
-    : { kind: "PaymentStateNoState" };
+    : "PaymentStateNoState";
 
 export const getRptId = (state: GlobalStateWithVerificaResponse): RptId =>
   state.wallet.payment.stack.head.rptId;


### PR DESCRIPTION
The navigation now moves to the summary of the payment before the data is fetched from pagoPA. Then, when the verifica response arrives, the screen is populated accordingly. 