### PR TITLE
Correzione refusi privacy

### DIFF
--- a/locales/it/privacy.md
+++ b/locales/it/privacy.md
@@ -1,23 +1,23 @@
-# INFORMATIVA PRIVACY PROGETTO IO
+# INFORMATIVA PRIVACY PROGETTO "io"
 
 La presente informativa sul trattamento
-dei dati personali effettuato nell’ambito dell’utilizzo di IO è fornita ai
-sensi dell’art. 13 del Regolamento (UE) 2016/679 del parlamento europeo e
+dei dati personali effettuato nell’ambito dell’utilizzo di **io** è fornita ai
+sensi dell’art. 13 del Regolamento (UE) 2016/679 del Parlamento europeo e
 del Consiglio del 27 aprile 2016.
 L’utilizzo dei servizi erogati tramite
-IO non modifica la titolarità rispetto ai Suoi dati personali. Pertanto, le
+**io** non modifica la titolarità rispetto ai suoi dati personali. Pertanto, le
 pubbliche amministrazioni, le società a controllo pubblico e i gestori di
-pubblici servizi che aderiscono a IO per rendere fruibili i loro servizi ai
-cittadini (di seguito anche solo **“Enti Erogatori”**)  restano i titolari
+pubblici servizi che aderiscono a **io** per rendere fruibili i loro servizi ai
+cittadini (di seguito anche solo **“enti erogatori”**)  restano i titolari
 del trattamento.
 L’Agenzia per l’Italia Digitale (“**AgID**”), cui è affidato
-il ruolo di gestire e mantenere la piattaforma IO, agisce in qualità di responsabile
-del trattamento, e tratterà i Suoi dati in conformità alle istruzioni impartite
-dagli Enti Erogatori.
-Nella sezione “Profilo” sono messe a Sua disposizione
-le informative sul trattamento dei dati personali degli Enti Erogatori. A
-complemento di queste, la presente informativa Le fornisce informazioni aggiuntive
-e specifiche sul trattamento effettuato per il tramite e nell’ambito di IO.
+il ruolo di gestire e mantenere la piattaforma **io**, agisce in qualità di responsabile
+del trattamento, e tratterà i suoi dati in conformità alle istruzioni impartite
+dagli enti erogatori.
+Nella sezione “Profilo” sono messe a sua disposizione
+le informative sul trattamento dei dati personali degli enti erogatori. A
+complemento di queste, la presente informativa le fornisce informazioni aggiuntive
+e specifiche sul trattamento effettuato per il tramite e nell’ambito di **io**.
 I
 dati personali oggetto di trattamento da parte di AgID sono quelli indicati
 al paragrafo 3.1 “Dati personali oggetto del Trattamento” del documento “Linee
@@ -27,32 +27,32 @@ accessibile dal sito www.agid.gov.it. Inoltre, al successivo paragrafo 3.2
 le finalità del trattamento.
 Tutti i dati personali oggetto di trattamento,
 inclusi eventuali dati sensibili, potranno essere oggetto di trattamento da
-parte degli Enti Erogatori per il tramite di AgID, fermo restando che tale
+parte degli enti erogatori per il tramite di AgID, fermo restando che tale
 trattamento non richiede uno specifico consenso da parte dell’utente in quanto
 finalizzato all’erogazione dei servizi erogati dal punto di accesso telematico
-di IO, e fondato sulla base giuridica costituita dalla normativa primaria
-già ampiamente indicata nel paragrafo “Introduzione” delle Linee guida già
-citate, nonché in attuazione delle stesse Linee guida.
+di **io**, e fondato sulla base giuridica costituita dalla normativa primaria
+già ampiamente indicata nel paragrafo “Introduzione” delle linee guida già
+citate, nonché in attuazione delle stesse linee guida.
 In relazione a tutte
 le finalità indicate, il trattamento dei dati avverrà in modo da garantire
 la sicurezza e la riservatezza.
-AgID, per l’erogazione dei servizi agli Enti
-Erogatori, potrà trasmettere e/o dare in gestione i dati personali raccolti
+AgID, per l’erogazione dei servizi agli enti
+erogatori, potrà trasmettere e/o dare in gestione i dati personali raccolti
 a suoi aventi causa, in qualità di sub-responsabili, preventivamente contrattualizzati
 per la sola erogazione dei servizi connessi alle finalità del trattamento.
 
 ### DIRITTI DELL’INTERESSATO
 
 Lei potrà esercitare i propri diritti nei confronti
-dei titolari del trattamento, gli Enti Erogatori, secondo quanto indicato
+dei titolari del trattamento, gli enti erogatori, secondo quanto indicato
 nelle rispettive informative rese disponibile nella sezione “Profilo”.
 La
-sospensione e/o cancellazione da IO comporta la cancellazione dei Suoi dati
-personali all’interno di IO, ma non comporta la cancellazione dei Suoi dati
-da parte dell’Ente Erogatore, cui dovrà rivolgere apposita richiesta ai sensi
+sospensione e/o cancellazione da **io** comporta la cancellazione dei suoi dati
+personali all’interno di **io**, ma non comporta la cancellazione dei suoi dati
+da parte dell’ente erogatore, cui dovrà rivolgere apposita richiesta ai sensi
 e in conformità con la relativa informativa.
 Per qualsiasi questione riguardante
-IO o informazione specifica sul trattamento dei dati effettuato nell’’ambito
+**io** o informazione specifica sul trattamento dei dati effettuato nell'ambito
 della stessa, può contattare l’AgID ai seguenti recapiti:
 Agenzia per l’Italia
 Digitale


### PR DESCRIPTION
Corretto uso delle maiuscole "questa informativa Le fornisce"
Eliminate una decina di maiuscole inutili
Il brand **io** va riportato non in maiuscola ma in forma minuscola, utilizzando il grassetto per evidenziarlo
Corretti un paio di refusi

Nel testo c'è un riferimento a un documento Agid che è introvabile sul web, aperta GitHub issue a riguardo
@matteodesanti 