### PR TITLE
Refactoring wallet saga and hot fix on wallet action loop

### DIFF
--- a/ts/api/pagopa.ts
+++ b/ts/api/pagopa.ts
@@ -15,7 +15,7 @@ import {
   TypeofApiParams
 } from "italia-ts-commons/lib/requests";
 
-import { NullableWallet, PspListResponse } from "../types/pagopa";
+import { NullableWallet, PagopaToken, PspListResponse } from "../types/pagopa";
 import { SessionResponse } from "../types/pagopa";
 import { TransactionListResponse } from "../types/pagopa";
 import { TransactionResponse } from "../types/pagopa";
@@ -82,7 +82,7 @@ const getSession: MapResponseType<
 };
 
 const getTransactions: (
-  pagoPaToken: string
+  pagoPaToken: PagopaToken
 ) => MapResponseType<
   GetTransactionsUsingGETT,
   200,
@@ -96,7 +96,7 @@ const getTransactions: (
 });
 
 const getWallets: (
-  pagoPaToken: string
+  pagoPaToken: PagopaToken
 ) => MapResponseType<
   GetWalletsUsingGETT,
   200,
@@ -110,7 +110,7 @@ const getWallets: (
 });
 
 const checkPayment: (
-  pagoPaToken: string
+  pagoPaToken: PagopaToken
 ) => CheckPaymentUsingGETT = pagoPaToken => ({
   method: "get",
   url: ({ id }) => `/v1/payments/${id}/actions/check`,
@@ -120,7 +120,7 @@ const checkPayment: (
 });
 
 const getPspList: (
-  pagoPaToken: string
+  pagoPaToken: PagopaToken
 ) => MapResponseType<
   GetPspListUsingGETT,
   200,
@@ -137,7 +137,7 @@ const getPspList: (
 });
 
 const updateWalletPsp: (
-  pagoPaToken: string
+  pagoPaToken: PagopaToken
 ) => MapResponseType<
   UpdateWalletUsingPUTT,
   200,
@@ -155,7 +155,7 @@ const updateWalletPsp: (
 });
 
 const boardCreditCard: (
-  pagoPaToken: string
+  pagoPaToken: PagopaToken
 ) => MapResponseType<
   AddWalletCreditCardUsingPOSTT,
   200,
@@ -173,7 +173,7 @@ const boardCreditCard: (
 });
 
 const postPayment: (
-  pagoPaToken: string
+  pagoPaToken: PagopaToken
 ) => MapResponseType<
   PayUsingPOSTT,
   200,
@@ -191,7 +191,7 @@ const postPayment: (
 });
 
 const boardPay: (
-  pagoPaToken: string
+  pagoPaToken: PagopaToken
 ) => MapResponseType<
   PayCreditCardVerificationUsingPOSTT,
   200,
@@ -211,7 +211,7 @@ const boardPay: (
 });
 
 const deleteWallet: (
-  pagoPaToken: string
+  pagoPaToken: PagopaToken
 ) => DeleteWalletUsingDELETET = pagoPaToken => ({
   method: "delete",
   url: ({ id }) => `/v1/wallet/${id}`,
@@ -232,26 +232,26 @@ export function PagoPaClient(
     getSession: (
       wt: string // wallet token
     ) => createFetchRequestForApi(getSession, options)({ token: wt }),
-    getWallets: (pagoPaToken: string) =>
+    getWallets: (pagoPaToken: PagopaToken) =>
       createFetchRequestForApi(getWallets(pagoPaToken), options)({}),
-    getTransactions: (pagoPaToken: string) =>
+    getTransactions: (pagoPaToken: PagopaToken) =>
       createFetchRequestForApi(getTransactions(pagoPaToken), options)({}),
     checkPayment: (
-      pagoPaToken: string,
+      pagoPaToken: PagopaToken,
       id: TypeofApiParams<CheckPaymentUsingGETT>["id"]
     ) =>
       createFetchRequestForApi(checkPayment(pagoPaToken), options)({
         id
       }),
     getPspList: (
-      pagoPaToken: string,
+      pagoPaToken: PagopaToken,
       idPayment: TypeofApiParams<GetPspListUsingGETT>["idPayment"]
     ) =>
       createFetchRequestForApi(getPspList(pagoPaToken), options)({
         idPayment
       }),
     updateWalletPsp: (
-      pagoPaToken: string,
+      pagoPaToken: PagopaToken,
       id: TypeofApiParams<UpdateWalletUsingPUTT>["id"],
       walletRequest: TypeofApiParams<UpdateWalletUsingPUTT>["walletRequest"]
     ) =>
@@ -260,7 +260,7 @@ export function PagoPaClient(
         walletRequest
       }),
     postPayment: (
-      pagoPaToken: string,
+      pagoPaToken: PagopaToken,
       id: TypeofApiParams<PayUsingPOSTT>["id"],
       payRequest: TypeofApiParams<PayUsingPOSTT>["payRequest"]
     ) =>
@@ -268,12 +268,15 @@ export function PagoPaClient(
         id,
         payRequest
       }),
-    boardCreditCard: (pagoPaToken: string, walletRequest: NullableWallet) =>
+    boardCreditCard: (
+      pagoPaToken: PagopaToken,
+      walletRequest: NullableWallet
+    ) =>
       createFetchRequestForApi(boardCreditCard(pagoPaToken), options)({
         walletRequest: { data: walletRequest }
       }),
     boardPay: (
-      pagoPaToken: string,
+      pagoPaToken: PagopaToken,
       payRequest: TypeofApiParams<
         PayCreditCardVerificationUsingPOSTT
       >["payRequest"]
@@ -282,7 +285,7 @@ export function PagoPaClient(
         payRequest
       }),
     deleteWallet: (
-      pagoPaToken: string,
+      pagoPaToken: PagopaToken,
       id: TypeofApiParams<DeleteWalletUsingDELETET>["id"]
     ) =>
       createFetchRequestForApi(deleteWallet(pagoPaToken), options)({

--- a/ts/components/messages/MessageCTABar.tsx
+++ b/ts/components/messages/MessageCTABar.tsx
@@ -128,7 +128,11 @@ class MessageCTABar extends React.PureComponent<Props> {
         const onPaymentCTAPress = () => {
           this.props.dispatch(paymentRequestMessage());
           this.props.dispatch(
-            paymentRequestTransactionSummaryFromRptId(rptId.value, amount.value)
+            paymentRequestTransactionSummaryFromRptId({
+              rptId: rptId.value,
+              initialAmount: amount.value,
+              kind: "fromRptId"
+            })
           );
         };
 

--- a/ts/components/wallet/PaymentBannerComponent.tsx
+++ b/ts/components/wallet/PaymentBannerComponent.tsx
@@ -116,7 +116,12 @@ const mapStateToProps = (state: GlobalState): ReduxMappedStateProps =>
     : { valid: false };
 
 const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedDispatchProps => ({
-  showSummary: () => dispatch(paymentRequestTransactionSummaryFromBanner())
+  showSummary: () =>
+    dispatch(
+      paymentRequestTransactionSummaryFromBanner({
+        kind: "fromBanner"
+      })
+    )
 });
 
 export default connect(

--- a/ts/sagas/wallet.ts
+++ b/ts/sagas/wallet.ts
@@ -9,7 +9,6 @@ import { none, Option, some } from "fp-ts/lib/Option";
 import { RptIdFromString } from "italia-ts-commons/lib/pagopa";
 import { AmountInEuroCents, RptId } from "italia-ts-commons/lib/pagopa";
 import {
-  IResponseType,
   TypeofApiCall,
   TypeofApiResponse
 } from "italia-ts-commons/lib/requests";
@@ -41,7 +40,6 @@ import I18n from "../i18n";
 import ROUTES from "../navigation/routes";
 
 import { logoutSuccess } from "../store/actions/authentication";
-import { storePagoPaToken } from "../store/actions/wallet/pagopa";
 import {
   paymentCompleted,
   paymentConfirmPaymentMethod,
@@ -137,75 +135,14 @@ import { constantPollingFetch, pagopaFetch } from "../utils/fetch";
 import { loginWithPinSaga } from "./startup/pinLoginSaga";
 import { watchPinResetSaga } from "./startup/watchPinResetSaga";
 
-// allow refreshing token this number of times
-const MAX_TOKEN_REFRESHES = 2;
+import {
+  fetchAndStorePagoPaToken,
+  fetchWithTokenRefresh
+} from "./wallet/utils";
 
 const navigateTo = (routeName: string, params?: object) => {
   return NavigationActions.navigate({ routeName, params });
 };
-
-// this function tries to carry out the provided
-// request, and refreshes the pagoPA token if a 401
-// is returned. Upon refreshing, it tries to
-// re-fetch the contents again for a maximum of
-// MAX_TOKEN_REFRESHES times.
-// If the request is successful (i.e. it does not
-// return a 401), the successful token is returned
-// along with the response (the caller will then
-// decide what to do with it)
-function* fetchWithTokenRefresh<T>(
-  request: (
-    pagoPaToken: string
-  ) => Promise<IResponseType<401, undefined> | undefined | T>,
-  pagoPaClient: PagoPaClient,
-  retries: number = MAX_TOKEN_REFRESHES
-): Iterator<T | undefined | Effect> {
-  if (retries === 0) {
-    return undefined;
-  }
-  const pagoPaToken: Option<string> = yield select(getPagoPaToken);
-  const response: SagaCallReturnType<typeof request> = yield call(
-    request,
-    pagoPaToken.getOrElse("") // empty token -> pagoPA returns a 401 and the app fetches a new one
-  );
-  if (response !== undefined) {
-    // BEWARE: since there is not an easy way to restrict T to an arbitrary union
-    // of IResponseType(s), we kind of take a leap of faith here and assume that T
-    // is always a union of IResponseType(s) together with undefined.
-    if ((response as any).status !== 401) {
-      // return code is not 401, the token
-      // has been "accepted" (the caller will
-      // then handle other error codes)
-      return response;
-    } else {
-      yield call(fetchAndStorePagoPaToken, pagoPaClient);
-
-      // and retry fetching the result
-      return yield call(
-        fetchWithTokenRefresh,
-        request,
-        pagoPaClient,
-        retries - 1
-      );
-    }
-  }
-  return undefined;
-}
-
-function* fetchAndStorePagoPaToken(pagoPaClient: PagoPaClient) {
-  const refreshTokenResponse: SagaCallReturnType<
-    typeof pagoPaClient.getSession
-  > = yield call(pagoPaClient.getSession, pagoPaClient.walletToken);
-  if (
-    refreshTokenResponse !== undefined &&
-    refreshTokenResponse.status === 200
-  ) {
-    // token fetched successfully, store it
-    yield put(
-      storePagoPaToken(some(refreshTokenResponse.value.data.sessionToken))
-    );
-  }
-}
 
 function* fetchTransactions(pagoPaClient: PagoPaClient): Iterator<Effect> {
   const response:

--- a/ts/sagas/wallet.ts
+++ b/ts/sagas/wallet.ts
@@ -121,6 +121,7 @@ import {
 import {
   CreditCard,
   NullableWallet,
+  PagopaToken,
   PayRequest,
   Psp,
   Wallet
@@ -191,7 +192,7 @@ function* addCreditCard(
       psp: undefined
     };
     // 1st call: boarding credit card
-    const boardCreditCard = (token: string) =>
+    const boardCreditCard = (token: PagopaToken) =>
       pagoPaClient.boardCreditCard(token, wallet);
     const responseBoardCC: SagaCallReturnType<
       typeof boardCreditCard
@@ -216,7 +217,7 @@ function* addCreditCard(
           : undefined
       }
     };
-    const boardPay = (token: string) =>
+    const boardPay = (token: PagopaToken) =>
       pagoPaClient.boardPay(token, payRequest);
     const responseBoardPay: SagaCallReturnType<typeof boardPay> = yield call(
       fetchWithTokenRefresh,
@@ -306,7 +307,7 @@ function* deleteWallet(
 ): Iterator<Effect> {
   try {
     yield put(walletManagementSetLoadingState());
-    const apiDeleteWallet = (token: string) =>
+    const apiDeleteWallet = (token: PagopaToken) =>
       pagoPaClient.deleteWallet(token, walletId);
     const response: SagaCallReturnType<typeof apiDeleteWallet> = yield call(
       fetchWithTokenRefresh,
@@ -617,7 +618,7 @@ function* fetchPspList(
 
   try {
     yield put(paymentSetLoadingState());
-    const apiGetPspList = (pagoPaToken: string) =>
+    const apiGetPspList = (pagoPaToken: PagopaToken) =>
       pagoPaClient.getPspList(pagoPaToken, paymentId);
     const response: SagaCallReturnType<typeof apiGetPspList> = yield call(
       fetchWithTokenRefresh,
@@ -742,7 +743,7 @@ function* checkPayment(
 ): Iterator<Effect> {
   try {
     yield put(paymentSetLoadingState());
-    const apiCheckPayment = (token: string) =>
+    const apiCheckPayment = (token: PagopaToken) =>
       pagoPaClient.checkPayment(token, paymentId);
     const response: SagaCallReturnType<typeof apiCheckPayment> = yield call(
       fetchWithTokenRefresh,
@@ -880,7 +881,7 @@ function* updatePspHandler(
 
   try {
     yield put(paymentSetLoadingState());
-    const apiUpdateWalletPsp = (pagoPaToken: string) =>
+    const apiUpdateWalletPsp = (pagoPaToken: PagopaToken) =>
       pagoPaClient.updateWalletPsp(pagoPaToken, walletId, action.payload);
     const response: SagaCallReturnType<typeof apiUpdateWalletPsp> = yield call(
       fetchWithTokenRefresh,
@@ -930,7 +931,7 @@ function* completionHandler(pagoPaClient: PagoPaClient) {
 
   try {
     yield put(paymentSetLoadingState());
-    const apiPostPayment = (pagoPaToken: string) =>
+    const apiPostPayment = (pagoPaToken: PagopaToken) =>
       pagoPaClient.postPayment(pagoPaToken, paymentId, {
         data: { tipo: "web", idWallet }
       });

--- a/ts/sagas/wallet/utils.ts
+++ b/ts/sagas/wallet/utils.ts
@@ -1,0 +1,76 @@
+import { Option, some } from "fp-ts/lib/Option";
+import { IResponseType } from "italia-ts-commons/lib/requests";
+import { call, Effect, put, select } from "redux-saga/effects";
+
+import { PagoPaClient } from "../../api/pagopa";
+
+import { storePagoPaToken } from "../../store/actions/wallet/pagopa";
+import { getPagoPaToken } from "../../store/reducers/wallet/pagopa";
+
+import { SagaCallReturnType } from "../../types/utils";
+
+// allow refreshing token this number of times
+const MAX_TOKEN_REFRESHES = 2;
+
+export function* fetchAndStorePagoPaToken(pagoPaClient: PagoPaClient) {
+  const refreshTokenResponse: SagaCallReturnType<
+    typeof pagoPaClient.getSession
+  > = yield call(pagoPaClient.getSession, pagoPaClient.walletToken);
+  if (
+    refreshTokenResponse !== undefined &&
+    refreshTokenResponse.status === 200
+  ) {
+    // token fetched successfully, store it
+    yield put(
+      storePagoPaToken(some(refreshTokenResponse.value.data.sessionToken))
+    );
+  }
+}
+
+// this function tries to carry out the provided
+// request, and refreshes the pagoPA token if a 401
+// is returned. Upon refreshing, it tries to
+// re-fetch the contents again for a maximum of
+// MAX_TOKEN_REFRESHES times.
+// If the request is successful (i.e. it does not
+// return a 401), the successful token is returned
+// along with the response (the caller will then
+// decide what to do with it)
+export function* fetchWithTokenRefresh<T>(
+  request: (
+    pagoPaToken: string
+  ) => Promise<IResponseType<401, undefined> | undefined | T>,
+  pagoPaClient: PagoPaClient,
+  retries: number = MAX_TOKEN_REFRESHES
+): Iterator<T | undefined | Effect> {
+  if (retries === 0) {
+    return undefined;
+  }
+  const pagoPaToken: Option<string> = yield select(getPagoPaToken);
+  const response: SagaCallReturnType<typeof request> = yield call(
+    request,
+    pagoPaToken.getOrElse("") // empty token -> pagoPA returns a 401 and the app fetches a new one
+  );
+  if (response !== undefined) {
+    // BEWARE: since there is not an easy way to restrict T to an arbitrary union
+    // of IResponseType(s), we kind of take a leap of faith here and assume that T
+    // is always a union of IResponseType(s) together with undefined.
+    if ((response as any).status !== 401) {
+      // return code is not 401, the token
+      // has been "accepted" (the caller will
+      // then handle other error codes)
+      return response;
+    } else {
+      yield call(fetchAndStorePagoPaToken, pagoPaClient);
+
+      // and retry fetching the result
+      return yield call(
+        fetchWithTokenRefresh,
+        request,
+        pagoPaClient,
+        retries - 1
+      );
+    }
+  }
+  return undefined;
+}

--- a/ts/screens/PinLoginScreen.tsx
+++ b/ts/screens/PinLoginScreen.tsx
@@ -65,7 +65,11 @@ class PinLoginScreen extends React.Component<Props> {
   };
 
   private goToPaymentSummary = () => {
-    this.props.dispatch(paymentRequestTransactionSummaryFromBanner());
+    this.props.dispatch(
+      paymentRequestTransactionSummaryFromBanner({
+        kind: "fromBanner"
+      })
+    );
   };
 
   // Method called when the CodeInput is filled

--- a/ts/screens/wallet/ConfirmCardDetailsScreen.tsx
+++ b/ts/screens/wallet/ConfirmCardDetailsScreen.tsx
@@ -155,8 +155,8 @@ const mapStateToProps = (state: GlobalState): ReduxMappedStateProps => {
 };
 
 const mapDispatchToProps = (dispatch: Dispatch): ReduMappedDispatchProps => ({
-  addCreditCard: (creditCard: CreditCard, favorite: boolean) =>
-    dispatch(addCreditCardRequest(creditCard, favorite))
+  addCreditCard: (creditCard: CreditCard, setAsFavorite: boolean) =>
+    dispatch(addCreditCardRequest({ creditCard, setAsFavorite }))
 });
 
 export default connect(

--- a/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
@@ -288,7 +288,12 @@ const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedDispatchProps => ({
   requestPinLogin: () => dispatch(paymentRequestPinLogin()),
   goBack: () => dispatch(paymentRequestGoBack()),
   pickPsp: () => dispatch(paymentRequestPickPsp()),
-  showSummary: () => dispatch(paymentRequestTransactionSummaryFromBanner()),
+  showSummary: () =>
+    dispatch(
+      paymentRequestTransactionSummaryFromBanner({
+        kind: "fromBanner"
+      })
+    ),
   onCancel: () => dispatch(paymentRequestCancel())
 });
 

--- a/ts/screens/wallet/payment/ManualDataInsertionScreen.tsx
+++ b/ts/screens/wallet/payment/ManualDataInsertionScreen.tsx
@@ -225,8 +225,14 @@ const mapStateToProps = (state: GlobalState): ReduxMappedStateProps => ({
 });
 
 const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedDispatchProps => ({
-  showTransactionSummary: (rptId: RptId, amount: AmountInEuroCents) =>
-    dispatch(paymentRequestTransactionSummaryFromRptId(rptId, amount)),
+  showTransactionSummary: (rptId: RptId, initialAmount: AmountInEuroCents) =>
+    dispatch(
+      paymentRequestTransactionSummaryFromRptId({
+        rptId,
+        initialAmount,
+        kind: "fromRptId"
+      })
+    ),
   goBack: () => dispatch(paymentRequestGoBack()),
   cancelPayment: () => dispatch(paymentRequestCancel())
 });

--- a/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
@@ -160,7 +160,12 @@ const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedDispatchProps => ({
   confirmPaymentMethod: (walletId: number) =>
     dispatch(paymentRequestConfirmPaymentMethod(walletId)),
   goBack: () => dispatch(paymentRequestGoBack()),
-  showSummary: () => dispatch(paymentRequestTransactionSummaryFromBanner())
+  showSummary: () =>
+    dispatch(
+      paymentRequestTransactionSummaryFromBanner({
+        kind: "fromBanner"
+      })
+    )
 });
 
 export default connect(

--- a/ts/screens/wallet/payment/ScanQrCodeScreen.tsx
+++ b/ts/screens/wallet/payment/ScanQrCodeScreen.tsx
@@ -235,8 +235,14 @@ const mapStateToProps = (state: GlobalState): ReduxMappedStateProps => ({
 });
 
 const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedDispatchProps => ({
-  showTransactionSummary: (rptId: RptId, amount: AmountInEuroCents) =>
-    dispatch(paymentRequestTransactionSummaryFromRptId(rptId, amount)),
+  showTransactionSummary: (rptId: RptId, initialAmount: AmountInEuroCents) =>
+    dispatch(
+      paymentRequestTransactionSummaryFromRptId({
+        rptId,
+        initialAmount,
+        kind: "fromRptId"
+      })
+    ),
   insertDataManually: () => dispatch(paymentRequestManualEntry()),
   goBack: () => dispatch(paymentRequestGoBack())
 });

--- a/ts/store/actions/constants.ts
+++ b/ts/store/actions/constants.ts
@@ -2,15 +2,6 @@
  * All the actions related constants.
  */
 
-// Wallet
-
-// (payment)
-export const PAYMENT_REQUEST_TRANSACTION_SUMMARY: "PAYMENT_REQUEST_TRANSACTION_SUMMARY" =
-  "PAYMENT_REQUEST_TRANSACTION_SUMMARY";
-// TODO: temporary, until integration with pagoPA occurs @https://www.pivotaltracker.com/story/show/159494746
-export const PAYMENT_UPDATE_PSP_IN_STATE: "PAYMENT_UPDATE_PSP_IN_STATE" =
-  "PAYMENT_UPDATE_PSP_IN_STATE";
-
 // Error
 export const ERROR_CLEAR: "ERROR_CLEAR" = "ERROR_CLEAR";
 

--- a/ts/store/actions/messages.ts
+++ b/ts/store/actions/messages.ts
@@ -8,9 +8,7 @@ import {
   createStandardAction
 } from "typesafe-actions";
 
-import { PaymentData } from "../../../definitions/backend/PaymentData";
 import { MessageWithContentPO } from "../../types/MessageWithContentPO";
-import { PAYMENT_REQUEST_TRANSACTION_SUMMARY } from "./constants";
 
 export const loadMessageSuccess = createStandardAction("MESSAGE_LOAD_SUCCESS")<
   MessageWithContentPO
@@ -55,10 +53,6 @@ export const navigateToMessageDetails = createStandardAction(
   "NAVIGATE_TO_MESSAGE_DETAILS"
 )<string>();
 
-export const startPayment = createStandardAction(
-  PAYMENT_REQUEST_TRANSACTION_SUMMARY
-)<PaymentData>();
-
 export type MessagesActions =
   | ActionType<typeof loadMessageSuccess>
   | ActionType<typeof loadMessageFailure>
@@ -69,5 +63,4 @@ export type MessagesActions =
   | ActionType<typeof loadMessagesCancel>
   | ActionType<typeof loadMessagesSuccess>
   | ActionType<typeof loadMessagesFailure>
-  | ActionType<typeof navigateToMessageDetails>
-  | ActionType<typeof startPayment>;
+  | ActionType<typeof navigateToMessageDetails>;

--- a/ts/store/actions/wallet/pagopa.ts
+++ b/ts/store/actions/wallet/pagopa.ts
@@ -1,9 +1,10 @@
 import { Option } from "fp-ts/lib/Option";
-import { ActionType, createAction } from "typesafe-actions";
+import { ActionType, createStandardAction } from "typesafe-actions";
 
-export const storePagoPaToken = createAction(
-  "PAGOPA_STORE_TOKEN",
-  resolve => (token: Option<string>) => resolve(token)
-);
+import { PagopaToken } from "../../../types/pagopa";
+
+export const storePagoPaToken = createStandardAction("PAGOPA_STORE_TOKEN")<
+  Option<PagopaToken>
+>();
 
 export type PagoPaActions = ActionType<typeof storePagoPaToken>;

--- a/ts/store/actions/wallet/payment.ts
+++ b/ts/store/actions/wallet/payment.ts
@@ -7,81 +7,19 @@ import {
 import { PaymentRequestsGetResponse } from "../../../../definitions/backend/PaymentRequestsGetResponse";
 import { PagoPaErrors } from "../../../types/errors";
 import { Psp } from "../../../types/pagopa";
-import {
-  PAYMENT_REQUEST_TRANSACTION_SUMMARY,
-  PAYMENT_UPDATE_PSP_IN_STATE
-} from "../constants";
-
-// for the first time the screen is being shown (i.e. after the
-// rptId has been passed (from qr code/manual entry/message)
-type PaymentRequestTransactionSummaryFromRptId = Readonly<{
-  type: typeof PAYMENT_REQUEST_TRANSACTION_SUMMARY;
-  kind: "fromRptId";
-  payload: {
-    rptId: RptId;
-    initialAmount: AmountInEuroCents;
-  };
-}>;
-
-// for when the user taps on the payment banner and gets redirected
-// to the summary of the payment
-export type PaymentRequestTransactionSummaryFromBanner = Readonly<{
-  type: typeof PAYMENT_REQUEST_TRANSACTION_SUMMARY;
-  kind: "fromBanner";
-}>;
-
-export type PaymentRequestTransactionSummaryActions =
-  | PaymentRequestTransactionSummaryFromRptId
-  | PaymentRequestTransactionSummaryFromBanner;
-
-type PaymentTransactionSummaryActions =
-  | ActionType<typeof paymentTransactionSummaryFromRptId>
-  | ActionType<typeof paymentTransactionSummaryFromBanner>;
 
 export const paymentCompleted = createStandardAction("PAYMENT_COMPLETED")();
 
-// TODO: temporary action until integration with pagoPA occurs
-// @https://www.pivotaltracker.com/story/show/159494746
-type PaymentUpdatePspInState = Readonly<{
-  type: typeof PAYMENT_UPDATE_PSP_IN_STATE;
+type PaymentUpdatePspInStatePayload = Readonly<{
   walletId: number;
-  payload: Psp; // pspId
+  psp: Psp; // pspId
 }>;
 
-/**
- * All possible payment actions
- */
-export type PaymentActions =
-  | ActionType<typeof paymentRequestQrCode>
-  | ActionType<typeof paymentQrCode>
-  | ActionType<typeof paymentRequestManualEntry>
-  | ActionType<typeof paymentRequestMessage>
-  | ActionType<typeof paymentManualEntry>
-  | PaymentRequestTransactionSummaryActions
-  | PaymentTransactionSummaryActions
-  | ActionType<typeof paymentRequestContinueWithPaymentMethods>
-  | ActionType<typeof paymentRequestPickPaymentMethod>
-  | ActionType<typeof paymentPickPaymentMethod>
-  | ActionType<typeof paymentInitialPickPaymentMethod>
-  | ActionType<typeof paymentRequestConfirmPaymentMethod>
-  | ActionType<typeof paymentConfirmPaymentMethod>
-  | ActionType<typeof paymentInitialConfirmPaymentMethod>
-  | ActionType<typeof paymentRequestPickPsp>
-  | ActionType<typeof paymentPickPsp>
-  | ActionType<typeof paymentInitialPickPsp>
-  | ActionType<typeof paymentUpdatePsp>
-  | PaymentUpdatePspInState // TODO: temporary, until integration with pagoPA occurs @https://www.pivotaltracker.com/story/show/159494746
-  | ActionType<typeof paymentRequestCompletion>
-  | ActionType<typeof paymentCompleted>
-  | ActionType<typeof paymentGoBack>
-  | ActionType<typeof paymentRequestGoBack>
-  | ActionType<typeof paymentSetLoadingState>
-  | ActionType<typeof paymentResetLoadingState>
-  | ActionType<typeof paymentCancel>
-  | ActionType<typeof paymentRequestCancel>
-  | ActionType<typeof paymentRequestPinLogin>
-  | ActionType<typeof paymentPinLogin>
-  | ActionType<typeof paymentFailure>;
+// TODO: temporary action until integration with pagoPA occurs
+// @https://www.pivotaltracker.com/story/show/159494746
+export const paymentUpdatePspInState = createStandardAction(
+  "PAYMENT_UPDATE_PSP_IN_STATE"
+)<PaymentUpdatePspInStatePayload>();
 
 export const paymentRequestQrCode = createStandardAction(
   "PAYMENT_REQUEST_QR_CODE"
@@ -101,19 +39,25 @@ export const paymentManualEntry = createStandardAction(
   "PAYMENT_MANUAL_ENTRY"
 )();
 
-export const paymentRequestTransactionSummaryFromRptId = (
-  rptId: RptId,
-  initialAmount: AmountInEuroCents
-): PaymentRequestTransactionSummaryFromRptId => ({
-  type: PAYMENT_REQUEST_TRANSACTION_SUMMARY,
-  kind: "fromRptId",
-  payload: { rptId, initialAmount }
-});
+type PaymentRequestTransactionSummaryFromRptIdPayload = Readonly<{
+  rptId: RptId;
+  initialAmount: AmountInEuroCents;
+  kind: "fromRptId";
+}>;
 
-export const paymentRequestTransactionSummaryFromBanner = (): PaymentRequestTransactionSummaryFromBanner => ({
-  type: PAYMENT_REQUEST_TRANSACTION_SUMMARY,
-  kind: "fromBanner"
-});
+// for the first time the screen is being shown (i.e. after the
+// rptId has been passed (from qr code/manual entry/message)
+export const paymentRequestTransactionSummaryFromRptId = createStandardAction(
+  "PAYMENT_REQUEST_TRANSACTION_SUMMARY"
+)<PaymentRequestTransactionSummaryFromRptIdPayload>();
+
+type PaymentRequestTransactionSummaryFromBannerPayload = Readonly<{
+  kind: "fromBanner";
+}>;
+
+export const paymentRequestTransactionSummaryFromBanner = createStandardAction(
+  "PAYMENT_REQUEST_TRANSACTION_SUMMARY"
+)<PaymentRequestTransactionSummaryFromBannerPayload>();
 
 // For when the user taps on the payment banner and gets redirected
 // to the summary of the payment.
@@ -126,6 +70,8 @@ export const paymentTransactionSummaryFromRptId = createAction(
   ) => resolve({ rptId, verificaResponse, initialAmount })
 );
 
+// for when the user taps on the payment banner and gets redirected
+// to the summary of the payment
 export const paymentTransactionSummaryFromBanner = createStandardAction(
   "PAYMENT_TRANSACTION_SUMMARY_FROM_BANNER"
 )();
@@ -142,15 +88,13 @@ export const paymentPickPaymentMethod = createStandardAction(
   "PAYMENT_PICK_PAYMENT_METHOD"
 )();
 
-export const paymentInitialPickPaymentMethod = createAction(
-  "PAYMENT_INITIAL_PICK_PAYMENT_METHOD",
-  resolve => (paymentId: string) => resolve(paymentId)
-);
+export const paymentInitialPickPaymentMethod = createStandardAction(
+  "PAYMENT_INITIAL_PICK_PAYMENT_METHOD"
+)<string>();
 
-export const paymentRequestConfirmPaymentMethod = createAction(
-  "PAYMENT_REQUEST_CONFIRM_PAYMENT_METHOD",
-  resolve => (walletId: number) => resolve(walletId)
-);
+export const paymentRequestConfirmPaymentMethod = createStandardAction(
+  "PAYMENT_REQUEST_CONFIRM_PAYMENT_METHOD"
+)<number>();
 
 export const paymentConfirmPaymentMethod = createAction(
   "PAYMENT_CONFIRM_PAYMENT_METHOD",
@@ -186,10 +130,9 @@ export const paymentPickPsp = createAction(
     resolve({ selectedPaymentMethod: walletId, pspList })
 );
 
-export const paymentUpdatePsp = createAction(
-  "PAYMENT_UPDATE_PSP",
-  resolve => (pspId: number) => resolve(pspId)
-);
+export const paymentUpdatePsp = createStandardAction("PAYMENT_UPDATE_PSP")<
+  number
+>();
 
 export const paymentRequestCompletion = createStandardAction(
   "PAYMENT_REQUEST_COMPLETION"
@@ -221,7 +164,41 @@ export const paymentRequestPinLogin = createStandardAction(
 
 export const paymentPinLogin = createStandardAction("PAYMENT_PIN_LOGIN")();
 
-export const paymentFailure = createAction(
-  "PAYMENT_FAILURE",
-  resolve => (error: PagoPaErrors) => resolve(error)
-);
+export const paymentFailure = createStandardAction("PAYMENT_FAILURE")<
+  PagoPaErrors
+>();
+
+/**
+ * All possible payment actions
+ */
+export type PaymentActions =
+  | ActionType<typeof paymentRequestQrCode>
+  | ActionType<typeof paymentQrCode>
+  | ActionType<typeof paymentRequestManualEntry>
+  | ActionType<typeof paymentRequestMessage>
+  | ActionType<typeof paymentManualEntry>
+  | ActionType<typeof paymentRequestTransactionSummaryFromBanner>
+  | ActionType<typeof paymentRequestTransactionSummaryFromRptId>
+  | ActionType<typeof paymentRequestContinueWithPaymentMethods>
+  | ActionType<typeof paymentRequestPickPaymentMethod>
+  | ActionType<typeof paymentPickPaymentMethod>
+  | ActionType<typeof paymentInitialPickPaymentMethod>
+  | ActionType<typeof paymentRequestConfirmPaymentMethod>
+  | ActionType<typeof paymentConfirmPaymentMethod>
+  | ActionType<typeof paymentInitialConfirmPaymentMethod>
+  | ActionType<typeof paymentRequestPickPsp>
+  | ActionType<typeof paymentPickPsp>
+  | ActionType<typeof paymentInitialPickPsp>
+  | ActionType<typeof paymentUpdatePsp>
+  | ActionType<typeof paymentUpdatePspInState> // TODO: temporary, until integration with pagoPA occurs @https://www.pivotaltracker.com/story/show/159494746
+  | ActionType<typeof paymentRequestCompletion>
+  | ActionType<typeof paymentCompleted>
+  | ActionType<typeof paymentGoBack>
+  | ActionType<typeof paymentRequestGoBack>
+  | ActionType<typeof paymentSetLoadingState>
+  | ActionType<typeof paymentResetLoadingState>
+  | ActionType<typeof paymentCancel>
+  | ActionType<typeof paymentRequestCancel>
+  | ActionType<typeof paymentRequestPinLogin>
+  | ActionType<typeof paymentPinLogin>
+  | ActionType<typeof paymentFailure>;

--- a/ts/store/actions/wallet/wallets.ts
+++ b/ts/store/actions/wallet/wallets.ts
@@ -54,11 +54,14 @@ export const creditCardDataCleanup = createStandardAction(
   "CREDIT_CARD_DATA_CLEANUP"
 )();
 
-export const addCreditCardRequest = createAction(
-  "ADD_CREDIT_CARD_REQUEST",
-  resolve => (creditCard: CreditCard, setAsFavorite: boolean) =>
-    resolve({ creditCard, setAsFavorite })
-);
+type AddCreditCardRequestPayload = Readonly<{
+  creditCard: CreditCard;
+  setAsFavorite: boolean;
+}>;
+
+export const addCreditCardRequest = createStandardAction(
+  "ADD_CREDIT_CARD_REQUEST"
+)<AddCreditCardRequestPayload>();
 
 export const addCreditCardCompleted = createStandardAction(
   "ADD_CREDIT_CARD_COMPLETED"

--- a/ts/store/reducers/wallet/pagopa.ts
+++ b/ts/store/reducers/wallet/pagopa.ts
@@ -1,12 +1,14 @@
 import { none, Option } from "fp-ts/lib/Option";
 import { isActionOf } from "typesafe-actions";
 
+import { PagopaToken } from "../../../types/pagopa";
+
 import { Action } from "../../actions/types";
 import { storePagoPaToken } from "../../actions/wallet/pagopa";
 import { GlobalState } from "../types";
 
 export type PagoPaState = Readonly<{
-  token: Option<string>;
+  token: Option<PagopaToken>;
 }>;
 
 const PAGOPA_INITIAL_STATE = {

--- a/ts/store/reducers/wallet/payment.ts
+++ b/ts/store/reducers/wallet/payment.ts
@@ -393,7 +393,9 @@ const summaryReducer: PaymentReducer = (
         state.stack,
         {
           kind: "PaymentStateSummary",
-          ...action.payload // rptId, verificaResponse, initialAmount
+          rptId: action.payload.rptId,
+          verificaResponse: action.payload.verificaResponse,
+          initialAmount: action.payload.initialAmount
         },
         ["PaymentStateSummary"]
       )

--- a/ts/store/reducers/wallet/wallets.ts
+++ b/ts/store/reducers/wallet/wallets.ts
@@ -7,8 +7,8 @@ import { values } from "lodash";
 import { createSelector } from "reselect";
 import { getType } from "typesafe-actions";
 import { CreditCard, Wallet } from "../../../types/pagopa";
-import { PAYMENT_UPDATE_PSP_IN_STATE } from "../../actions/constants";
 import { Action } from "../../actions/types";
+import { paymentUpdatePspInState } from "../../actions/wallet/payment";
 import {
   creditCardDataCleanup,
   fetchWalletsSuccess,
@@ -136,15 +136,15 @@ const reducer = (
     // (then, the psp will be updated on the server side,
     // and, by fetching the existing cards the psp will be
     // automatically updated)
-    case PAYMENT_UPDATE_PSP_IN_STATE:
+    case getType(paymentUpdatePspInState):
       return {
         ...state,
         list: {
           ...state.list,
-          [action.walletId]: {
-            ...state.list[action.walletId],
-            idPsp: action.payload.id,
-            psp: action.payload
+          [action.payload.walletId]: {
+            ...state.list[action.payload.walletId],
+            idPsp: action.payload.psp.id,
+            psp: action.payload.psp
           }
         }
       };

--- a/ts/types/pagopa.ts
+++ b/ts/types/pagopa.ts
@@ -102,6 +102,9 @@ export const Wallet = repP(
 );
 export type Wallet = t.TypeOf<typeof Wallet>;
 
+/**
+ * A Wallet that has not being saved yet
+ */
 export type NullableWallet = ReplaceProp1<
   Wallet,
   "idWallet" | "favourite",

--- a/ts/types/pagopa.ts
+++ b/ts/types/pagopa.ts
@@ -1,4 +1,5 @@
 import * as t from "io-ts";
+import { tag } from "italia-ts-commons/lib/types";
 
 import {
   ReplaceProp1,
@@ -167,9 +168,25 @@ export const WalletListResponse = repP(
 export type WalletListResponse = t.TypeOf<typeof WalletListResponse>;
 
 /**
+ * A tagged string type for the PagoPA SessionToken
+ */
+
+interface IPagopaTokenTag {
+  kind: "IPagopaTokenTag";
+}
+
+export const PagopaToken = tag<IPagopaTokenTag>()(t.string);
+export type PagopaToken = t.TypeOf<typeof PagopaToken>;
+
+/**
  * A Session
  */
-export const Session = reqP(SessionPagoPA, "sessionToken", "Session");
+export const Session = repP(
+  reqP(SessionPagoPA, "sessionToken"),
+  "sessionToken",
+  PagopaToken,
+  "Session"
+);
 
 export type Session = t.TypeOf<typeof Session>;
 


### PR DESCRIPTION
we broke the action loop by calling `getType` on a non-typesafe-actions action