### PR TITLE
[#161048326] Wallet refactoring: removing unnecessary and unsafe selects and a lot more

### DIFF
--- a/docs/wallet/routes.puml
+++ b/docs/wallet/routes.puml
@@ -1,0 +1,25 @@
+@startuml
+hide empty description
+
+[*] --> P_TRANSACTION_SUMMARY : prTransactionSummaryFromRptId
+[*] --> P_TRANSACTION_SUMMARY : prTransactionSummaryFromBanner
+
+P_TRANSACTION_SUMMARY --> P_PICK_PAYMENT_METHOD : prContinueWithPaymentMethods\n(no-fav-wallet)
+P_TRANSACTION_SUMMARY --> P_PICK_PSP : prContinueWithPaymentMethods\n(fav-wallet,[psps] > 1)
+P_TRANSACTION_SUMMARY --> P_CONFIRM_PAYMENT_METHOD : prContinueWithPaymentMethods\n(fav-wallet,[psps] === 1)
+
+P_PICK_PAYMENT_METHOD --> P_PICK_PSP : prConfirmPaymentMethod\n(select-wallet,[psps] > 1)
+P_PICK_PAYMENT_METHOD --> P_CONFIRM_PAYMENT_METHOD : prConfirmPaymentMethod\n(select-wallet,[psps] === 1)
+P_PICK_PAYMENT_METHOD --> P_TRANSACTION_SUMMARY : prTransactionSummaryFromBanner
+
+P_PICK_PSP --> P_PICK_PSP : pUpdatePsp,\nprConfirmPaymentMethod
+P_PICK_PSP --> P_CONFIRM_PAYMENT_METHOD : pUpdatePsp,\nprConfirmPaymentMethod
+
+P_CONFIRM_PAYMENT_METHOD --> P_PICK_PAYMENT_METHOD : prPickPaymentMethod
+P_CONFIRM_PAYMENT_METHOD --> PIN_LOGIN_SCREEN : prPinLogin
+P_CONFIRM_PAYMENT_METHOD --> P_PICK_PSP : prPickPsp
+P_CONFIRM_PAYMENT_METHOD --> P_TRANSACTION_SUMMARY : prTransactionSummaryFromBanner
+
+PIN_LOGIN_SCREEN --> W_TRANSACTION_DETAILS : prCompletion
+
+@enduml

--- a/docs/wallet/saga.puml
+++ b/docs/wallet/saga.puml
@@ -1,0 +1,165 @@
+@startuml
+
+start
+fork
+  #orange:paymentRequestTransactionSummaryFromRptId;
+  #hotpink:PAYMENT_TRANSACTION_SUMMARY;
+  #cyan:paymentSetLoadingState;
+  if (getVerificaRpt) then (ok)
+    #cyan:setPaymentStateToSummary;
+  else (ko)
+    #cyan:paymentFailure;
+  endif
+  #cyan:paymentResetLoadingState;
+
+fork again
+
+  #orange:paymentRequestTransactionSummaryFromBanner;
+  #cyan:setPaymentStateToSummaryWithPaymentId;
+  #hotpink:PAYMENT_TRANSACTION_SUMMARY;
+
+fork again
+
+  #orange:paymentRequestContinueWithPaymentMethods;
+  #red:getFavoriteWalletId;
+  #red:isGlobalStateWithPaymentId;
+  #red:getRptId;
+  #red:getPaymentContextCode;
+  #red:getCurrentAmount;
+  if (isGlobalStateWithPaymentId) then (no)
+    #cyan:paymentSetLoadingState;
+    :attivaRpt;
+    :fetchPaymentId;
+    #cyan:paymentResetLoadingState;
+  endif
+  if (paymentId) then (some)
+    #cyan:paymentSetLoadingState;
+    :checkPayment;
+    #cyan:paymentResetLoadingState;
+  endif
+  if (favoriteWallet) then (some)
+    #red:specificWalletSelector(walletId);
+    if (wallet) then (some)
+      #red:getPaymentId;
+      #cyan:paymentSetLoadingState;
+      :getPspList;
+      #cyan:paymentResetLoadingState;
+      if (shouldShowPspList) then (yes)
+        if (paymentId) then (defined)
+          #cyan:setPaymentStateFromSummaryToPickPsp;
+        else (no)
+          #cyan:setPaymentStateToPickPsp;
+        endif
+        #hotpink:PAYMENT_PICK_PSP;
+      else (no)
+        if (paymentId) then (defined)
+          #cyan:setPaymentStateFromSummaryToConfirmPaymentMethod;
+        else (undefined)
+          #cyan:setPaymentStateToConfirmPaymentMethod;
+        endif
+        #hotpink:PAYMENT_CONFIRM_PAYMENT_METHOD;
+      endif
+    endif
+  else (none)
+    if (paymentId) then (defined)
+      #cyan:setPaymentStateFromSummaryToPickPaymentMethod;
+    else (undefined)
+      #cyan:setPaymentStateToPickPaymentMethod;
+    endif
+    #hotpink:PAYMENT_PICK_PAYMENT_METHOD;
+  endif
+fork again
+
+  #orange:paymentRequestPickPaymentMethod;
+  if (paymentId) then (defined)
+    #cyan:setPaymentStateFromSummaryToPickPaymentMethod;
+  else (undefined)
+    #cyan:setPaymentStateToPickPaymentMethod;
+  endif
+  #hotpink:PAYMENT_PICK_PAYMENT_METHOD;
+
+fork again
+
+  #orange:paymentRequestConfirmPaymentMethod;
+  #red:specificWalletSelector(idWallet);
+  if (wallet) then (some)
+    #red:getPaymentId;
+    #cyan:paymentSetLoadingState;
+    :getPspList;
+    #cyan:paymentResetLoadingState;
+    if (shouldShowPspList) then (yes)
+      if (paymentId) then (defined)
+        #cyan:setPaymentStateFromSummaryToPickPsp;
+      else (no)
+        #cyan:setPaymentStateToPickPsp;
+      endif
+      #hotpink:PAYMENT_PICK_PSP;
+    else (no)
+      if (paymentId) then (defined)
+        #cyan:setPaymentStateFromSummaryToConfirmPaymentMethod;
+      else (undefined)
+        #cyan:setPaymentStateToConfirmPaymentMethod;
+      endif
+      #hotpink:PAYMENT_CONFIRM_PAYMENT_METHOD;
+    endif
+  endif
+
+fork again
+
+  #orange:paymentRequestPickPsp;
+  #red:getSelectedPaymentMethod;
+  #red:getPspList;
+  #cyan:setPaymentStateToPickPsp;
+  #hotpink:PAYMENT_PICK_PSP;
+
+fork again
+
+  #orange:paymentUpdatePsp;
+  #red:getSelectedPaymentMethod;
+  #cyan:paymentSetLoadingState;
+  :updateWalletPsp;
+  if (updateWalletPsp) then (ok)
+    :getWallets;
+    if (getWallets) then (ok)
+      #cyan:fetchWalletsSuccess;
+    else (ko)
+      #cyan:fetchWalletsFailure;
+    endif
+    #cyan:paymentRequestConfirmPaymentMethod;
+  else (ko)
+    #cyan:paymentFailure;
+  endif
+  #cyan:paymentResetLoadingState;
+
+fork again
+
+  #orange:paymentRequestCompletion;
+  #red:getSelectedPaymentMethod;
+  #red:getPaymentId;
+  #cyan:paymentSetLoadingState;
+  :postPayment;
+  if (postPayment) then (ok)
+    :getTransactions;
+    if (getTransactions) then (ok)
+      #cyan:fetchTransactionsSuccess;
+    else (ko)
+      #cyan:fetchTransactionsFailure;
+    endif
+    #cyan:selectTransactionForDetails;
+    #cyan:selectWalletForDetails;
+    #hotpink:WALLET_TRANSACTION_DETAILS;
+    #cyan:resetPaymentState;
+  else (ko)
+    #cyan:paymentFailure;
+  endif
+  #cyan:paymentResetLoadingState;
+
+fork again
+
+  #orange:paymentRequestPinLogin;
+  #cyan:setPaymentStateToPinLogin;
+  #green:loginWithPinSaga;
+  #cyan:paymentRequestCompletion;
+end fork
+
+@enduml

--- a/docs/wallet/states.puml
+++ b/docs/wallet/states.puml
@@ -1,0 +1,51 @@
+@startuml
+hide empty description
+
+title Wallet State Model
+
+Summary : rptid : verificaResponse : initialAmount
+
+SummaryWithPaymentId : rptId : verificaResponse : initialAmount : paymentId
+
+PickPaymentMethod : rptId : verificaResponse : initialAmount : paymentId
+
+ConfirmPaymentMethod : rptId : verificaResponse : initialAmount : paymentId : selectedPaymentMethod : pspList
+
+PickPsp : rptId : verificaResponse : initialAmount : paymentId : selectedPaymentMethod : pspList
+
+PinLogin : rptId : verificaResponse : initialAmount : paymentId : selectedPaymentMethod : pspList
+
+[*] --> QrCode : ToQrCode
+[*] --> Summary : ToSummary
+
+QrCode --> ManualEntry : ToManualEntry
+
+QrCode --> Summary : ToSummary
+ManualEntry --> Summary : ToSummary
+
+PickPaymentMethod --> SummaryWithPaymentId : ToSummaryWithPaymentId
+ConfirmPaymentMethod --> SummaryWithPaymentId : ToSummaryWithPaymentId
+PickPsp --> SummaryWithPaymentId : ToSummaryWithPaymentId
+
+Summary --> PickPaymentMethod : FromSummaryToPickPaymentMethod
+
+SummaryWithPaymentId --> PickPaymentMethod : ToPickPaymentMethod
+ConfirmPaymentMethod --> PickPaymentMethod : ToPickPaymentMethod
+
+Summary --> ConfirmPaymentMethod : FromSummaryToConfirmPaymentMethod
+
+PickPaymentMethod --> ConfirmPaymentMethod : ToConfirmPaymentMethod
+SummaryWithPaymentId --> ConfirmPaymentMethod : ToConfirmPaymentMethod
+PickPsp --> ConfirmPaymentMethod : ToConfirmPaymentMethod
+
+Summary --> PickPsp : FromSummaryToPickPsp
+
+SummaryWithPaymentId --> PickPsp : ToPickPsp
+ConfirmPaymentMethod --> PickPsp : ToPickPsp
+PickPaymentMethod --> PickPsp : ToPickPsp
+
+ConfirmPaymentMethod --> PinLogin : ToPinLogin
+
+PinLogin --> [*] : resetState
+
+@enduml

--- a/ios/ItaliaApp.xcodeproj/project.pbxproj
+++ b/ios/ItaliaApp.xcodeproj/project.pbxproj
@@ -1599,7 +1599,7 @@
 				CODE_SIGN_ENTITLEMENTS = ItaliaApp/ItaliaApp.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 64;
+				CURRENT_PROJECT_VERSION = 65;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = BC8NKY5TF7;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1640,7 +1640,7 @@
 				CODE_SIGN_ENTITLEMENTS = ItaliaApp/ItaliaApp.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 64;
+				CURRENT_PROJECT_VERSION = 65;
 				DEVELOPMENT_TEAM = BC8NKY5TF7;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ios/ItaliaApp/Info.plist
+++ b/ios/ItaliaApp/Info.plist
@@ -34,7 +34,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>64</string>
+	<string>65</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/ios/ItaliaAppTests/Info.plist
+++ b/ios/ItaliaAppTests/Info.plist
@@ -19,6 +19,6 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>64</string>
+	<string>65</string>
 </dict>
 </plist>

--- a/ts/api/pagopa.ts
+++ b/ts/api/pagopa.ts
@@ -45,7 +45,7 @@ import {
   UpdateWalletUsingPUTT
 } from "../../definitions/pagopa/requestTypes";
 
-import { defaultRetryingFetch } from "../utils/fetch";
+import { defaultRetryingFetch, pagopaFetch } from "../utils/fetch";
 
 type MapTypeInApiResponse<T, S extends number, B> = T extends IResponseType<
   S,
@@ -223,7 +223,8 @@ const deleteWallet: (
 export function PagoPaClient(
   baseUrl: string,
   walletToken: string,
-  fetchApi: typeof fetch = defaultRetryingFetch()
+  fetchApi: typeof fetch = defaultRetryingFetch(),
+  altFetchApi: typeof fetch = pagopaFetch()
 ) {
   const options = { baseUrl, fetchApi };
 
@@ -240,7 +241,10 @@ export function PagoPaClient(
       pagoPaToken: PagopaToken,
       id: TypeofApiParams<CheckPaymentUsingGETT>["id"]
     ) =>
-      createFetchRequestForApi(checkPayment(pagoPaToken), options)({
+      createFetchRequestForApi(checkPayment(pagoPaToken), {
+        ...options,
+        fetchApi: altFetchApi
+      })({
         id
       }),
     getPspList: (

--- a/ts/components/messages/MessageCTABar.tsx
+++ b/ts/components/messages/MessageCTABar.tsx
@@ -9,8 +9,8 @@ import { ServicePublic } from "../../../definitions/backend/ServicePublic";
 import I18n from "../../i18n";
 import { ReduxProps } from "../../store/actions/types";
 import {
-  paymentRequestMessage,
-  paymentRequestTransactionSummaryFromRptId
+  paymentRequestTransactionSummaryFromRptId,
+  startPaymentSaga
 } from "../../store/actions/wallet/payment";
 import variables from "../../theme/variables";
 import { MessageWithContentPO } from "../../types/MessageWithContentPO";
@@ -126,7 +126,7 @@ class MessageCTABar extends React.PureComponent<Props> {
 
       if (isSome(amount) && isSome(rptId)) {
         const onPaymentCTAPress = () => {
-          this.props.dispatch(paymentRequestMessage());
+          this.props.dispatch(startPaymentSaga());
           this.props.dispatch(
             paymentRequestTransactionSummaryFromRptId({
               rptId: rptId.value,

--- a/ts/components/wallet/PaymentBannerComponent.tsx
+++ b/ts/components/wallet/PaymentBannerComponent.tsx
@@ -17,9 +17,9 @@ import { Dispatch } from "../../store/actions/types";
 import { paymentRequestTransactionSummaryFromBanner } from "../../store/actions/wallet/payment";
 import { GlobalState } from "../../store/reducers/types";
 import {
-  getCurrentAmount,
+  getCurrentAmountFromGlobalStateWithVerificaResponse,
   getPaymentReason,
-  getPaymentRecipient,
+  getPaymentRecipientFromGlobalStateWithVerificaResponse,
   isGlobalStateWithVerificaResponse
 } from "../../store/reducers/wallet/payment";
 import { UNKNOWN_PAYMENT_REASON, UNKNOWN_RECIPIENT } from "../../types/unknown";
@@ -110,8 +110,12 @@ const mapStateToProps = (state: GlobalState): ReduxMappedStateProps =>
         paymentReason: getPaymentReason(state).getOrElse(
           UNKNOWN_PAYMENT_REASON
         ), // this could be empty as per pagoPA definition
-        currentAmount: getCurrentAmount(state),
-        recipient: getPaymentRecipient(state).getOrElse(UNKNOWN_RECIPIENT) // this could be empty as per pagoPA definition
+        currentAmount: getCurrentAmountFromGlobalStateWithVerificaResponse(
+          state
+        ),
+        recipient: getPaymentRecipientFromGlobalStateWithVerificaResponse(
+          state
+        ).getOrElse(UNKNOWN_RECIPIENT) // this could be empty as per pagoPA definition
       }
     : { valid: false };
 

--- a/ts/components/wallet/PaymentSummaryComponent.tsx
+++ b/ts/components/wallet/PaymentSummaryComponent.tsx
@@ -10,18 +10,13 @@ import * as React from "react";
 import { Image, Platform, StyleSheet } from "react-native";
 import { Col, Grid, Row } from "react-native-easy-grid";
 import { NavigationScreenProp, NavigationState } from "react-navigation";
-import { connect } from "react-redux";
+
 import { WalletStyles } from "../../components/styles/wallet";
+
 import I18n from "../../i18n";
-import { GlobalState } from "../../store/reducers/types";
-import {
-  getCurrentAmount,
-  getInitialAmount,
-  getPaymentReason,
-  isGlobalStateWithVerificaResponse
-} from "../../store/reducers/wallet/payment";
+
 import variables from "../../theme/variables";
-import { UNKNOWN_PAYMENT_REASON } from "../../types/unknown";
+
 import { buildAmount } from "../../utils/stringBuilder";
 
 type ReduxMappedStateProps =
@@ -207,16 +202,4 @@ class PaymentSummaryComponent extends React.Component<Props> {
   }
 }
 
-const mapStateToProps = (state: GlobalState): ReduxMappedStateProps =>
-  isGlobalStateWithVerificaResponse(state)
-    ? {
-        hasVerificaResponse: true,
-        amount: getInitialAmount(state),
-        updatedAmount: getCurrentAmount(state),
-        paymentReason: getPaymentReason(state).getOrElse(UNKNOWN_PAYMENT_REASON)
-      }
-    : {
-        hasVerificaResponse: false
-      };
-
-export default connect(mapStateToProps)(PaymentSummaryComponent);
+export default PaymentSummaryComponent;

--- a/ts/components/wallet/TransactionsList.tsx
+++ b/ts/components/wallet/TransactionsList.tsx
@@ -200,7 +200,7 @@ const mapStateToProps = (
 
 const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedDispatchProps => ({
   selectTransaction: item => dispatch(selectTransactionForDetails(item)),
-  selectWallet: item => dispatch(selectWalletForDetails(item))
+  selectWallet: (item: number) => dispatch(selectWalletForDetails(item))
 });
 
 export default connect(

--- a/ts/components/wallet/WalletLayout.tsx
+++ b/ts/components/wallet/WalletLayout.tsx
@@ -25,7 +25,10 @@ import { connect } from "react-redux";
 import I18n from "../../i18n";
 import ROUTES from "../../navigation/routes";
 import { Dispatch } from "../../store/actions/types";
-import { paymentRequestQrCode } from "../../store/actions/wallet/payment";
+import {
+  setPaymentStateToQrCode,
+  startPaymentSaga
+} from "../../store/actions/wallet/payment";
 import variables from "../../theme/variables";
 import { Wallet } from "../../types/pagopa";
 import GoBackButton from "../GoBackButton";
@@ -95,7 +98,8 @@ type NoCards = Readonly<{
 export type CardType = FullCard | HeaderCard | FannedCards | NoCards;
 
 type ReduxMappedProps = Readonly<{
-  startPayment: () => void;
+  setPaymentStateToQrCode: () => void;
+  startPaymentSaga: () => void;
 }>;
 
 type OwnProps = Readonly<{
@@ -235,7 +239,14 @@ class WalletLayout extends React.Component<Props> {
         </ScrollView>
         {this.props.showPayButton && (
           <View footer={true}>
-            <Button block={true} onPress={() => this.props.startPayment()}>
+            <Button
+              block={true}
+              onPress={() => {
+                this.props.setPaymentStateToQrCode();
+                this.props.navigation.navigate(ROUTES.PAYMENT_SCAN_QR_CODE);
+                this.props.startPaymentSaga();
+              }}
+            >
               <IconFont name="io-qr" style={{ color: variables.colorWhite }} />
               <Text>{I18n.t("wallet.payNotice")}</Text>
             </Button>
@@ -247,7 +258,8 @@ class WalletLayout extends React.Component<Props> {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedProps => ({
-  startPayment: () => dispatch(paymentRequestQrCode())
+  setPaymentStateToQrCode: () => dispatch(setPaymentStateToQrCode()),
+  startPaymentSaga: () => dispatch(startPaymentSaga())
 });
 
 export default connect(

--- a/ts/components/wallet/card/CardBody.tsx
+++ b/ts/components/wallet/card/CardBody.tsx
@@ -47,9 +47,7 @@ export default class CardBody extends React.Component<CardProps> {
         <Row
           style={CreditCardStyles.rowStyle}
           onPress={() =>
-            mainAction !== undefined
-              ? mainAction(this.props.item.idWallet)
-              : undefined
+            mainAction !== undefined ? mainAction(this.props.item) : undefined
           }
         >
           <Right>

--- a/ts/components/wallet/card/FooterRow.tsx
+++ b/ts/components/wallet/card/FooterRow.tsx
@@ -83,7 +83,7 @@ class FooterRow extends React.Component<Props> {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedProps => ({
-  selectWallet: item => dispatch(selectWalletForDetails(item))
+  selectWallet: (item: number) => dispatch(selectWalletForDetails(item))
 });
 
 export default connect(

--- a/ts/components/wallet/card/index.tsx
+++ b/ts/components/wallet/card/index.tsx
@@ -96,7 +96,7 @@ export type CardProps = Readonly<{
   lastUsage?: boolean;
   whiteLine?: boolean;
   logoPosition?: LogoPosition;
-  mainAction?: (cardId: number) => void;
+  mainAction?: (wallet: Wallet) => void;
   flatBottom?: boolean;
   headerOnly?: boolean;
   rotated?: boolean;

--- a/ts/sagas/notifications.ts
+++ b/ts/sagas/notifications.ts
@@ -12,6 +12,7 @@ import { PlatformEnum } from "../../definitions/backend/Platform";
 import { CreateOrUpdateInstallationT } from "../../definitions/backend/requestTypes";
 import { updateNotificationInstallationFailure } from "../store/actions/notifications";
 import { notificationsInstallationSelector } from "../store/reducers/notifications/installation";
+import { GlobalState } from "../store/reducers/types";
 import { SagaCallReturnType } from "../types/utils";
 
 const notificationsPlatform: PlatformEnum = Platform.select({
@@ -30,7 +31,7 @@ export function* updateInstallationSaga(
   // Get the notifications installation data from the store
   const notificationsInstallation: ReturnType<
     typeof notificationsInstallationSelector
-  > = yield select(notificationsInstallationSelector);
+  > = yield select<GlobalState>(notificationsInstallationSelector);
 
   // Check if the notification server token is available (non available on iOS simulator)
   if (notificationsInstallation.token === undefined) {

--- a/ts/sagas/profile.ts
+++ b/ts/sagas/profile.ts
@@ -24,6 +24,7 @@ import {
   profileUpsertSuccess
 } from "../store/actions/profile";
 import { profileSelector } from "../store/reducers/profile";
+import { GlobalState } from "../store/reducers/types";
 
 import { SagaCallReturnType } from "../types/utils";
 
@@ -59,9 +60,9 @@ function* createOrUpdateProfileSaga(
   action: ActionType<typeof profileUpsertRequest>
 ): Iterator<Effect> {
   // Get the current Profile from the state
-  const profileState: ReturnType<typeof profileSelector> = yield select(
-    profileSelector
-  );
+  const profileState: ReturnType<typeof profileSelector> = yield select<
+    GlobalState
+  >(profileSelector);
 
   if (!profileState) {
     // somewhing's wrong, we don't even have an AuthenticatedProfile meaning

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -29,6 +29,7 @@ import {
   PendingMessageState,
   pendingMessageStateSelector
 } from "../store/reducers/notifications/pendingMessage";
+import { GlobalState } from "../store/reducers/types";
 import { PinString } from "../types/PinString";
 import { SagaCallReturnType } from "../types/utils";
 import { getPin } from "../utils/keychain";
@@ -60,7 +61,7 @@ function* initializeApplicationSaga(): IterableIterator<Effect> {
   // Whether the user is currently logged in.
   const previousSessionToken: ReturnType<
     typeof sessionTokenSelector
-  > = yield select(sessionTokenSelector);
+  > = yield select<GlobalState>(sessionTokenSelector);
 
   // Unless we have a valid session token already, login until we have one.
   const sessionToken: SagaCallReturnType<
@@ -101,7 +102,7 @@ function* initializeApplicationSaga(): IterableIterator<Effect> {
   // tslint:disable-next-line: no-let
   let maybeSessionInformation: ReturnType<
     typeof sessionInfoSelector
-  > = yield select(sessionInfoSelector);
+  > = yield select<GlobalState>(sessionInfoSelector);
   if (isSessionRefreshed || maybeSessionInformation.isNone()) {
     // let's try to load the session information from the backend.
     maybeSessionInformation = yield call(
@@ -131,7 +132,9 @@ function* initializeApplicationSaga(): IterableIterator<Effect> {
     return;
   }
   const userProfile = maybeUserProfile.value;
-  const maybeIdp: Option<IdentityProvider> = yield select(idpSelector);
+  const maybeIdp: Option<IdentityProvider> = yield select<GlobalState>(
+    idpSelector
+  );
 
   setInstabugProfileAttributes(userProfile, maybeIdp);
 
@@ -217,7 +220,7 @@ function* initializeApplicationSaga(): IterableIterator<Effect> {
   yield fork(watchPinResetSaga);
 
   // Check if we have a pending notification message
-  const pendingMessageState: PendingMessageState = yield select(
+  const pendingMessageState: PendingMessageState = yield select<GlobalState>(
     pendingMessageStateSelector
   );
 
@@ -231,7 +234,7 @@ function* initializeApplicationSaga(): IterableIterator<Effect> {
     // Navigate to message details screen
     yield put(navigateToMessageDetailScreenAction(messageId));
     // Push the MAIN navigator in the history to handle the back button
-    const navigationState: NavigationState = yield select(
+    const navigationState: NavigationState = yield select<GlobalState>(
       navigationStateSelector
     );
     yield put(

--- a/ts/sagas/startup/authenticationSaga.ts
+++ b/ts/sagas/startup/authenticationSaga.ts
@@ -12,6 +12,7 @@ import { resetToAuthenticationRoute } from "../../store/actions/navigation";
 import { NavigationActions } from "react-navigation";
 import ROUTES from "../../navigation/routes";
 import { isSessionExpiredSelector } from "../../store/reducers/authentication";
+import { GlobalState } from "../../store/reducers/types";
 import { SessionToken } from "../../types/SessionToken";
 
 /**
@@ -21,7 +22,9 @@ import { SessionToken } from "../../types/SessionToken";
 export function* authenticationSaga(): IterableIterator<Effect | SessionToken> {
   yield put(analyticsAuthenticationStarted());
 
-  const isSessionExpired: boolean = yield select(isSessionExpiredSelector);
+  const isSessionExpired: boolean = yield select<GlobalState>(
+    isSessionExpiredSelector
+  );
 
   // Reset the navigation stack and navigate to the authentication screen
   if (isSessionExpired) {

--- a/ts/sagas/startup/checkAcceptedTosSaga.ts
+++ b/ts/sagas/startup/checkAcceptedTosSaga.ts
@@ -8,15 +8,16 @@ import {
   tosAcceptSuccess
 } from "../../store/actions/onboarding";
 import { isTosAcceptedSelector } from "../../store/reducers/onboarding";
+import { GlobalState } from "../../store/reducers/types";
 
 export function* checkAcceptedTosSaga(): IterableIterator<Effect> {
   // From the state we check whether the user has already accepted the ToS
   // FIXME: ToS can change over time, this step should eventually check whether
   //        the user has accepted the latest version of the ToS and store the
   //        information in the user profile.
-  const isTosAccepted: ReturnType<typeof isTosAcceptedSelector> = yield select(
-    isTosAcceptedSelector
-  );
+  const isTosAccepted: ReturnType<typeof isTosAcceptedSelector> = yield select<
+    GlobalState
+  >(isTosAcceptedSelector);
 
   if (!isTosAccepted) {
     // Navigate to the TosScreen

--- a/ts/sagas/startup/saveNavigationStateSaga.ts
+++ b/ts/sagas/startup/saveNavigationStateSaga.ts
@@ -6,6 +6,7 @@ import ROUTES from "../../navigation/routes";
 
 import { setDeepLink } from "../../store/actions/deepLink";
 import { navigationStateSelector } from "../../store/reducers/navigation";
+import { GlobalState } from "../../store/reducers/types";
 
 /**
  * Saves the navigation state in the deep link state so that when the app
@@ -16,7 +17,7 @@ import { navigationStateSelector } from "../../store/reducers/navigation";
 export function* saveNavigationStateSaga(): IterableIterator<Effect> {
   const navigationState: ReturnType<
     typeof navigationStateSelector
-  > = yield select(navigationStateSelector);
+  > = yield select<GlobalState>(navigationStateSelector);
   const currentRoute = navigationState.routes[
     navigationState.index
   ] as NavigationStateRoute<NavigationParams>;

--- a/ts/sagas/startup/watchApplicationActivitySaga.ts
+++ b/ts/sagas/startup/watchApplicationActivitySaga.ts
@@ -21,6 +21,7 @@ import {
   PendingMessageState,
   pendingMessageStateSelector
 } from "../../store/reducers/notifications/pendingMessage";
+import { GlobalState } from "../../store/reducers/types";
 import { saveNavigationStateSaga } from "../startup/saveNavigationStateSaga";
 
 /**
@@ -68,9 +69,9 @@ export function* watchApplicationActivitySaga(): IterableIterator<Effect> {
         yield put(startApplicationInitialization());
       } else {
         // Check if we have a pending notification message
-        const pendingMessageState: PendingMessageState = yield select(
-          pendingMessageStateSelector
-        );
+        const pendingMessageState: PendingMessageState = yield select<
+          GlobalState
+        >(pendingMessageStateSelector);
         if (pendingMessageState) {
           // We have a pending notification message to handle
           const messageId = pendingMessageState.id;
@@ -79,7 +80,7 @@ export function* watchApplicationActivitySaga(): IterableIterator<Effect> {
           // Navigate to message details screen
           yield put(navigateToMessageDetailScreenAction(messageId));
           // Push the MAIN navigator in the history to handle the back button
-          const navigationState: NavigationState = yield select(
+          const navigationState: NavigationState = yield select<GlobalState>(
             navigationStateSelector
           );
           yield put(

--- a/ts/sagas/startup/watchLoadMessagesSaga.ts
+++ b/ts/sagas/startup/watchLoadMessagesSaga.ts
@@ -46,6 +46,7 @@ import {
   serviceByIdSelector,
   servicesByIdSelector
 } from "../../store/reducers/entities/services/servicesById";
+import { GlobalState } from "../../store/reducers/types";
 import {
   MessageWithContentPO,
   toMessageWithContentPO
@@ -66,7 +67,7 @@ export function* loadMessage(
   // If we already have the message in the store just return it
   const cachedMessage: ReturnType<
     ReturnType<typeof messageByIdSelector>
-  > = yield select(messageByIdSelector(id));
+  > = yield select<GlobalState>(messageByIdSelector(id));
   if (cachedMessage) {
     return right(cachedMessage);
   }
@@ -105,7 +106,7 @@ export function* loadService(
   // If we already have the service in the store just return it
   const cachedService: ReturnType<
     ReturnType<typeof serviceByIdSelector>
-  > = yield select(serviceByIdSelector(id));
+  > = yield select<GlobalState>(serviceByIdSelector(id));
   if (cachedService) {
     return right(cachedService);
   }
@@ -145,12 +146,12 @@ export function* loadMessages(
     // Load already cached messages from the store
     const cachedMessagesById: ReturnType<
       typeof messagesByIdSelector
-    > = yield select(messagesByIdSelector);
+    > = yield select<GlobalState>(messagesByIdSelector);
 
     // Load already cached services from the store
     const cachedServicesById: ReturnType<
       typeof servicesByIdSelector
-    > = yield select(servicesByIdSelector);
+    > = yield select<GlobalState>(servicesByIdSelector);
 
     // Request the list of messages from the Backend
     const response: SagaCallReturnType<typeof getMessages> = yield call(

--- a/ts/sagas/wallet.ts
+++ b/ts/sagas/wallet.ts
@@ -55,7 +55,6 @@ import {
   paymentUpdatePsp,
   resetPaymentState,
   setPaymentStateFromSummaryToConfirmPaymentMethod,
-  setPaymentStateFromSummaryToPickPaymentMethod,
   setPaymentStateFromSummaryToPickPsp,
   setPaymentStateToConfirmPaymentMethod,
   setPaymentStateToPickPaymentMethod,
@@ -399,7 +398,7 @@ function* watchPaymentSaga(
         break;
       }
       case getType(paymentRequestPickPaymentMethod): {
-        yield fork(pickPaymentMethodHandler);
+        yield fork(pickPaymentMethodHandler, action.payload.paymentId);
         break;
       }
       case getType(paymentRequestConfirmPaymentMethod): {
@@ -789,13 +788,9 @@ function* confirmPaymentMethodHandler(
   );
 }
 
-function* pickPaymentMethodHandler(paymentId?: string) {
+function* pickPaymentMethodHandler(paymentId: string) {
   // show screen with list of payment methods available
-  yield put(
-    paymentId
-      ? setPaymentStateFromSummaryToPickPaymentMethod(paymentId)
-      : setPaymentStateToPickPaymentMethod()
-  );
+  yield put(setPaymentStateToPickPaymentMethod(paymentId));
   yield put(navigateTo(ROUTES.PAYMENT_PICK_PAYMENT_METHOD));
 }
 

--- a/ts/sagas/wallet.ts
+++ b/ts/sagas/wallet.ts
@@ -812,11 +812,9 @@ function* updatePspHandler(
   try {
     yield put(paymentSetLoadingState());
     const apiUpdateWalletPsp = (pagoPaToken: PagopaToken) =>
-      pagoPaClient.updateWalletPsp(
-        pagoPaToken,
-        wallet.idWallet,
-        action.payload.pspId
-      );
+      pagoPaClient.updateWalletPsp(pagoPaToken, wallet.idWallet, {
+        data: { idPsp: action.payload.pspId }
+      });
     const response: SagaCallReturnType<typeof apiUpdateWalletPsp> = yield call(
       fetchWithTokenRefresh,
       apiUpdateWalletPsp,

--- a/ts/sagas/wallet.ts
+++ b/ts/sagas/wallet.ts
@@ -45,7 +45,6 @@ import {
   paymentRequestConfirmPaymentMethod,
   paymentRequestContinueWithPaymentMethods,
   paymentRequestGoBack,
-  paymentRequestManualEntry,
   paymentRequestMessage,
   paymentRequestPickPaymentMethod,
   paymentRequestPickPsp,
@@ -61,7 +60,6 @@ import {
   setPaymentStateFromSummaryToPickPaymentMethod,
   setPaymentStateFromSummaryToPickPsp,
   setPaymentStateToConfirmPaymentMethod,
-  setPaymentStateToManualEntry,
   setPaymentStateToPickPaymentMethod,
   setPaymentStateToPickPsp,
   setPaymentStateToQrCode,
@@ -367,7 +365,6 @@ function* watchPaymentSaga(
 ): Iterator<Effect> {
   while (true) {
     const action:
-      | ActionType<typeof paymentRequestManualEntry>
       | ActionType<typeof paymentRequestTransactionSummaryFromRptId>
       | ActionType<typeof paymentRequestTransactionSummaryFromBanner>
       | ActionType<typeof paymentRequestContinueWithPaymentMethods>
@@ -380,7 +377,6 @@ function* watchPaymentSaga(
       | ActionType<typeof paymentRequestCancel>
       | ActionType<typeof resetPaymentState>
       | ActionType<typeof paymentRequestPinLogin> = yield take([
-      getType(paymentRequestManualEntry),
       getType(paymentRequestTransactionSummaryFromRptId),
       getType(paymentRequestTransactionSummaryFromBanner),
       getType(paymentRequestContinueWithPaymentMethods),
@@ -401,10 +397,6 @@ function* watchPaymentSaga(
     }
 
     switch (action.type) {
-      case getType(paymentRequestManualEntry): {
-        yield fork(enterDataManuallyHandler, action, pagoPaClient);
-        break;
-      }
       case getType(paymentRequestTransactionSummaryFromRptId):
       case getType(paymentRequestTransactionSummaryFromBanner): {
         yield fork(
@@ -469,17 +461,6 @@ function* cancelPaymentHandler(_: ActionType<typeof paymentRequestCancel>) {
 function* goBackHandler(_: ActionType<typeof paymentRequestGoBack>) {
   yield put(goBackOnePaymentState()); // return to previous state
   yield put(NavigationActions.back());
-}
-
-function* enterDataManuallyHandler(
-  _: ActionType<typeof paymentRequestManualEntry>,
-  __: PagoPaClient
-): Iterator<Effect> {
-  // from the QR code screen the user selected
-  // the option for entering the data manually
-  // -> navigate to manual data insertion screen
-  yield put(setPaymentStateToManualEntry());
-  yield put(navigateTo(ROUTES.PAYMENT_MANUAL_DATA_INSERTION));
 }
 
 function* showTransactionSummaryHandler(

--- a/ts/sagas/wallet.ts
+++ b/ts/sagas/wallet.ts
@@ -55,7 +55,6 @@ import {
   paymentUpdatePsp,
   resetPaymentState,
   setPaymentStateFromSummaryToConfirmPaymentMethod,
-  setPaymentStateFromSummaryToPickPsp,
   setPaymentStateToConfirmPaymentMethod,
   setPaymentStateToPickPaymentMethod,
   setPaymentStateToPickPsp,
@@ -509,7 +508,7 @@ function* showPickPsp(
   wallet: Wallet,
   pspList: ReadonlyArray<Psp>
 ) {
-  yield put(setPaymentStateFromSummaryToPickPsp(wallet, pspList, paymentId));
+  yield put(setPaymentStateToPickPsp(wallet, pspList, paymentId));
   yield put(navigateTo(ROUTES.PAYMENT_PICK_PSP));
 }
 
@@ -795,9 +794,9 @@ function* pickPaymentMethodHandler(paymentId: string) {
 }
 
 function* pickPspHandler(action: ActionType<typeof paymentRequestPickPsp>) {
-  const pspList = action.payload.pspList;
+  const { wallet, pspList, paymentId } = action.payload;
 
-  yield put(setPaymentStateToPickPsp(action.payload.wallet, pspList));
+  yield put(setPaymentStateToPickPsp(wallet, pspList, paymentId));
   yield put(navigateTo(ROUTES.PAYMENT_PICK_PSP));
 }
 

--- a/ts/sagas/wallet.ts
+++ b/ts/sagas/wallet.ts
@@ -54,7 +54,6 @@ import {
   paymentSetLoadingState,
   paymentUpdatePsp,
   resetPaymentState,
-  setPaymentStateFromSummaryToConfirmPaymentMethod,
   setPaymentStateToConfirmPaymentMethod,
   setPaymentStateToPickPaymentMethod,
   setPaymentStateToPickPsp,
@@ -487,19 +486,11 @@ function* showTransactionSummaryFromBannerHandler() {
 }
 
 function* showConfirmPaymentMethod(
-  paymentIdOrUndefined: string | undefined,
+  paymentId: string,
   wallet: Wallet,
   pspList: ReadonlyArray<Psp>
 ) {
-  yield put(
-    paymentIdOrUndefined === undefined
-      ? setPaymentStateToConfirmPaymentMethod(wallet, pspList)
-      : setPaymentStateFromSummaryToConfirmPaymentMethod(
-          wallet,
-          pspList,
-          paymentIdOrUndefined
-        )
-  );
+  yield put(setPaymentStateToConfirmPaymentMethod(wallet, pspList, paymentId));
   yield put(navigateTo(ROUTES.PAYMENT_CONFIRM_PAYMENT_METHOD));
 }
 

--- a/ts/sagas/wallet/utils.ts
+++ b/ts/sagas/wallet/utils.ts
@@ -6,6 +6,7 @@ import { PagoPaClient } from "../../api/pagopa";
 import { PagopaToken } from "../../types/pagopa";
 
 import { storePagoPaToken } from "../../store/actions/wallet/pagopa";
+import { GlobalState } from "../../store/reducers/types";
 import { getPagoPaToken } from "../../store/reducers/wallet/pagopa";
 
 import { SagaCallReturnType } from "../../types/utils";
@@ -47,7 +48,9 @@ export function* fetchWithTokenRefresh<T>(
   if (retries === 0) {
     return undefined;
   }
-  const pagoPaToken: Option<PagopaToken> = yield select(getPagoPaToken);
+  const pagoPaToken: Option<PagopaToken> = yield select<GlobalState>(
+    getPagoPaToken
+  );
   const response: SagaCallReturnType<typeof request> = yield call(
     request,
     pagoPaToken.getOrElse("" as PagopaToken) // empty token -> pagoPA returns a 401 and the app fetches a new one

--- a/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
@@ -81,7 +81,11 @@ type ReduxMappedStateProps = Readonly<{
 
 type ReduxMappedDispatchProps = Readonly<{
   pickPaymentMethod: (paymentId: string) => void;
-  pickPsp: (wallet: Wallet, pspList: ReadonlyArray<Psp>) => void;
+  pickPsp: (
+    wallet: Wallet,
+    pspList: ReadonlyArray<Psp>,
+    paymentId: string
+  ) => void;
   // requestCompletion: () => void;
   requestPinLogin: (wallet: Wallet, paymentId: string) => void;
   goBack: () => void;
@@ -206,7 +210,9 @@ class ConfirmPaymentMethodScreen extends React.Component<Props, never> {
                       : I18n.t("payment.noPsp")}
                     <Text
                       link={true}
-                      onPress={() => this.props.pickPsp(wallet, pspList)}
+                      onPress={() =>
+                        this.props.pickPsp(wallet, pspList, paymentId)
+                      }
                     >
                       {I18n.t("payment.changePsp")}
                     </Text>
@@ -300,8 +306,8 @@ const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedDispatchProps => ({
   requestPinLogin: (wallet: Wallet, paymentId: string) =>
     dispatch(paymentRequestPinLogin({ wallet, paymentId })),
   goBack: () => dispatch(paymentRequestGoBack()),
-  pickPsp: (wallet: Wallet, pspList: ReadonlyArray<Psp>) =>
-    dispatch(paymentRequestPickPsp({ wallet, pspList })),
+  pickPsp: (wallet: Wallet, pspList: ReadonlyArray<Psp>, paymentId: string) =>
+    dispatch(paymentRequestPickPsp({ wallet, pspList, paymentId })),
   showSummary: () => dispatch(paymentRequestTransactionSummaryFromBanner()),
   onCancel: () => dispatch(paymentRequestCancel())
 });

--- a/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
@@ -80,7 +80,7 @@ type ReduxMappedStateProps = Readonly<{
       }>);
 
 type ReduxMappedDispatchProps = Readonly<{
-  pickPaymentMethod: () => void;
+  pickPaymentMethod: (paymentId: string) => void;
   pickPsp: (wallet: Wallet, pspList: ReadonlyArray<Psp>) => void;
   // requestCompletion: () => void;
   requestPinLogin: (wallet: Wallet, paymentId: string) => void;
@@ -246,7 +246,7 @@ class ConfirmPaymentMethodScreen extends React.Component<Props, never> {
               block={true}
               light={true}
               bordered={true}
-              onPress={_ => this.props.pickPaymentMethod()}
+              onPress={_ => this.props.pickPaymentMethod(paymentId)}
             >
               <Text>{I18n.t("wallet.ConfirmPayment.change")}</Text>
             </Button>
@@ -295,7 +295,8 @@ const mapStateToProps = (state: GlobalState): ReduxMappedStateProps => {
 };
 
 const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedDispatchProps => ({
-  pickPaymentMethod: () => dispatch(paymentRequestPickPaymentMethod()),
+  pickPaymentMethod: (paymentId: string) =>
+    dispatch(paymentRequestPickPaymentMethod({ paymentId })),
   requestPinLogin: (wallet: Wallet, paymentId: string) =>
     dispatch(paymentRequestPinLogin({ wallet, paymentId })),
   goBack: () => dispatch(paymentRequestGoBack()),

--- a/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
@@ -49,14 +49,16 @@ import { createErrorSelector } from "../../../store/reducers/error";
 import { createLoadingSelector } from "../../../store/reducers/loading";
 import { GlobalState } from "../../../store/reducers/types";
 import {
-  getCurrentAmount,
+  getCurrentAmountFromGlobalStateWithSelectedPaymentMethod,
+  getPaymentIdFromGlobalStateWithSelectedPaymentMethod,
   getPaymentStep,
-  isGlobalStateWithSelectedPaymentMethod,
-  selectedPaymentMethodSelector
+  getPspListFromGlobalStateWithSelectedPaymentMethod,
+  getSelectedPaymentMethodFromGlobalStateWithSelectedPaymentMethod,
+  isGlobalStateWithSelectedPaymentMethod
 } from "../../../store/reducers/wallet/payment";
 import { feeExtractor } from "../../../store/reducers/wallet/wallets";
 import { mapErrorCodeToMessage } from "../../../types/errors";
-import { Wallet } from "../../../types/pagopa";
+import { Psp, Wallet } from "../../../types/pagopa";
 import { UNKNOWN_AMOUNT } from "../../../types/unknown";
 import { buildAmount } from "../../../utils/stringBuilder";
 
@@ -73,13 +75,15 @@ type ReduxMappedStateProps = Readonly<{
         wallet: Wallet;
         amount: AmountInEuroCents;
         fee: AmountInEuroCents;
+        paymentId: string;
+        pspList: ReadonlyArray<Psp>;
       }>);
 
 type ReduxMappedDispatchProps = Readonly<{
   pickPaymentMethod: () => void;
-  pickPsp: () => void;
+  pickPsp: (wallet: Wallet, pspList: ReadonlyArray<Psp>) => void;
   // requestCompletion: () => void;
-  requestPinLogin: () => void;
+  requestPinLogin: (wallet: Wallet, paymentId: string) => void;
   goBack: () => void;
   showSummary: () => void;
   onCancel: () => void;
@@ -117,7 +121,7 @@ class ConfirmPaymentMethodScreen extends React.Component<Props, never> {
     if (!this.props.valid) {
       return null;
     }
-
+    const { wallet, paymentId, pspList } = this.props;
     const amount = AmountInEuroCentsFromNumber.encode(this.props.amount);
     const fee = AmountInEuroCentsFromNumber.encode(this.props.fee);
     const totalAmount = this.getTotalAmount(amount, fee);
@@ -195,12 +199,15 @@ class ConfirmPaymentMethodScreen extends React.Component<Props, never> {
                   <View spacer={true} large={true} />
                   <Text style={WalletStyles.textCenter}>
                     {/* TODO: the proper UI needs to be defined for changing PSP */}
-                    {this.props.wallet.psp !== undefined
+                    {wallet.psp !== undefined
                       ? `${I18n.t("payment.currentPsp")} ${
-                          this.props.wallet.psp.businessName
+                          wallet.psp.businessName
                         } `
                       : I18n.t("payment.noPsp")}
-                    <Text link={true} onPress={() => this.props.pickPsp()}>
+                    <Text
+                      link={true}
+                      onPress={() => this.props.pickPsp(wallet, pspList)}
+                    >
                       {I18n.t("payment.changePsp")}
                     </Text>
                   </Text>
@@ -228,7 +235,7 @@ class ConfirmPaymentMethodScreen extends React.Component<Props, never> {
           <Button
             block={true}
             primary={true}
-            onPress={() => this.props.requestPinLogin()}
+            onPress={() => this.props.requestPinLogin(wallet, paymentId)}
           >
             <Text>{I18n.t("wallet.ConfirmPayment.goToPay")}</Text>
           </Button>
@@ -264,15 +271,19 @@ const mapStateToProps = (state: GlobalState): ReduxMappedStateProps => {
     getPaymentStep(state) === "PaymentStateConfirmPaymentMethod" &&
     isGlobalStateWithSelectedPaymentMethod(state)
   ) {
-    const wallet = selectedPaymentMethodSelector(state);
+    const wallet = getSelectedPaymentMethodFromGlobalStateWithSelectedPaymentMethod(
+      state
+    );
     const feeOrUndefined = feeExtractor(wallet);
     return {
       isLoading: createLoadingSelector(["PAYMENT"])(state),
       error: createErrorSelector(["PAYMENT"])(state),
       valid: true,
       wallet,
-      amount: getCurrentAmount(state),
-      fee: feeOrUndefined === undefined ? UNKNOWN_AMOUNT : feeOrUndefined
+      amount: getCurrentAmountFromGlobalStateWithSelectedPaymentMethod(state),
+      fee: feeOrUndefined === undefined ? UNKNOWN_AMOUNT : feeOrUndefined,
+      paymentId: getPaymentIdFromGlobalStateWithSelectedPaymentMethod(state),
+      pspList: getPspListFromGlobalStateWithSelectedPaymentMethod(state)
     };
   } else {
     return {
@@ -285,9 +296,11 @@ const mapStateToProps = (state: GlobalState): ReduxMappedStateProps => {
 
 const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedDispatchProps => ({
   pickPaymentMethod: () => dispatch(paymentRequestPickPaymentMethod()),
-  requestPinLogin: () => dispatch(paymentRequestPinLogin()),
+  requestPinLogin: (wallet: Wallet, paymentId: string) =>
+    dispatch(paymentRequestPinLogin({ wallet, paymentId })),
   goBack: () => dispatch(paymentRequestGoBack()),
-  pickPsp: () => dispatch(paymentRequestPickPsp()),
+  pickPsp: (wallet: Wallet, pspList: ReadonlyArray<Psp>) =>
+    dispatch(paymentRequestPickPsp({ wallet, pspList })),
   showSummary: () => dispatch(paymentRequestTransactionSummaryFromBanner()),
   onCancel: () => dispatch(paymentRequestCancel())
 });

--- a/ts/screens/wallet/payment/PickPspScreen.tsx
+++ b/ts/screens/wallet/payment/PickPspScreen.tsx
@@ -37,13 +37,15 @@ import { createErrorSelector } from "../../../store/reducers/error";
 import { createLoadingSelector } from "../../../store/reducers/loading";
 import { GlobalState } from "../../../store/reducers/types";
 import {
+  getPaymentIdFromGlobalStateWithSelectedPaymentMethod,
   getPaymentStep,
-  getPspList,
+  getPspListFromGlobalStateWithSelectedPaymentMethod,
+  getSelectedPaymentMethodFromGlobalStateWithSelectedPaymentMethod,
   isGlobalStateWithSelectedPaymentMethod
 } from "../../../store/reducers/wallet/payment";
 import variables from "../../../theme/variables";
 import { mapErrorCodeToMessage } from "../../../types/errors";
-import { Psp } from "../../../types/pagopa";
+import { Psp, Wallet } from "../../../types/pagopa";
 import { buildAmount, centsToAmount } from "../../../utils/stringBuilder";
 
 type ReduxMappedStateProps = Readonly<{
@@ -54,11 +56,13 @@ type ReduxMappedStateProps = Readonly<{
     | Readonly<{
         valid: true;
         pspList: ReadonlyArray<Psp>;
+        wallet: Wallet;
+        paymentId: string;
       }>
     | Readonly<{ valid: false }>);
 
 type ReduxMappedDispatchProps = Readonly<{
-  pickPsp: (pspId: number) => void;
+  pickPsp: (pspId: number, wallet: Wallet, paymentId: string) => void;
   goBack: () => void;
   onCancel: () => void;
 }>;
@@ -107,6 +111,8 @@ class PickPspScreen extends React.Component<Props, never> {
       return null;
     }
 
+    const { wallet, paymentId } = this.props;
+
     return (
       <Container>
         <AppHeader>
@@ -140,7 +146,9 @@ class PickPspScreen extends React.Component<Props, never> {
             data={this.props.pspList}
             keyExtractor={item => item.id.toString()}
             renderItem={({ item }) => (
-              <TouchableOpacity onPress={() => this.props.pickPsp(item.id)}>
+              <TouchableOpacity
+                onPress={() => this.props.pickPsp(item.id, wallet, paymentId)}
+              >
                 <View style={style.listItem}>
                   <Grid>
                     <Col size={6}>
@@ -183,13 +191,18 @@ const mapStateToProps = (state: GlobalState): ReduxMappedStateProps => ({
   isGlobalStateWithSelectedPaymentMethod(state)
     ? {
         valid: true,
-        pspList: getPspList(state)
+        pspList: getPspListFromGlobalStateWithSelectedPaymentMethod(state),
+        wallet: getSelectedPaymentMethodFromGlobalStateWithSelectedPaymentMethod(
+          state
+        ),
+        paymentId: getPaymentIdFromGlobalStateWithSelectedPaymentMethod(state)
       }
     : { valid: false })
 });
 
 const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedDispatchProps => ({
-  pickPsp: (pspId: number) => dispatch(paymentUpdatePsp(pspId)),
+  pickPsp: (pspId: number, wallet: Wallet, paymentId: string) =>
+    dispatch(paymentUpdatePsp({ pspId, wallet, paymentId })),
   goBack: () => dispatch(paymentRequestGoBack()),
   onCancel: () => dispatch(paymentRequestCancel())
 });

--- a/ts/screens/wallet/payment/ScanQrCodeScreen.tsx
+++ b/ts/screens/wallet/payment/ScanQrCodeScreen.tsx
@@ -20,21 +20,31 @@ import { Dimensions, ScrollView, StyleSheet } from "react-native";
 import QRCodeScanner from "react-native-qrcode-scanner";
 import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
+
 import { InstabugButtons } from "../../../components/InstabugButtons";
 import AppHeader from "../../../components/ui/AppHeader";
 import FooterWithButtons from "../../../components/ui/FooterWithButtons";
+
 import I18n from "../../../i18n";
+
 import { Dispatch } from "../../../store/actions/types";
+
+import ROUTES from "../../../navigation/routes";
+
 import {
   paymentRequestGoBack,
-  paymentRequestManualEntry,
-  paymentRequestTransactionSummaryFromRptId
+  paymentRequestTransactionSummaryFromRptId,
+  setPaymentStateToManualEntry
 } from "../../../store/actions/wallet/payment";
 import { GlobalState } from "../../../store/reducers/types";
 import { getPaymentStep } from "../../../store/reducers/wallet/payment";
+
 import variables from "../../../theme/variables";
+
 import { ComponentProps } from "../../../types/react";
+
 import { decodePagoPaQrCode } from "../../../utils/payment";
+
 import { CameraMarker } from "./CameraMarker";
 
 type ReduxMappedStateProps = Readonly<{
@@ -43,7 +53,7 @@ type ReduxMappedStateProps = Readonly<{
 
 type ReduxMappedDispatchProps = Readonly<{
   showTransactionSummary: (rptId: RptId, amount: AmountInEuroCents) => void;
-  insertDataManually: () => void;
+  setPaymentStateToManualEntry: () => void;
   goBack: () => void;
 }>;
 
@@ -165,7 +175,10 @@ class ScanQrCodeScreen extends React.Component<Props, State> {
     const primaryButtonProps = {
       block: true,
       primary: true,
-      onPress: () => this.props.insertDataManually(),
+      onPress: () => {
+        this.props.setPaymentStateToManualEntry();
+        this.props.navigation.navigate(ROUTES.PAYMENT_MANUAL_DATA_INSERTION);
+      },
       title: I18n.t("wallet.QRtoPay.setManually")
     };
 
@@ -242,7 +255,7 @@ const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedDispatchProps => ({
         initialAmount
       })
     ),
-  insertDataManually: () => dispatch(paymentRequestManualEntry()),
+  setPaymentStateToManualEntry: () => dispatch(setPaymentStateToManualEntry()),
   goBack: () => dispatch(paymentRequestGoBack())
 });
 

--- a/ts/screens/wallet/payment/TransactionSummaryScreen.tsx
+++ b/ts/screens/wallet/payment/TransactionSummaryScreen.tsx
@@ -7,8 +7,9 @@
  * - "back" & "cancel" behavior to be implemented @https://www.pivotaltracker.com/story/show/159229087
  */
 
-import { Option } from "fp-ts/lib/Option";
+import { none, Option, some } from "fp-ts/lib/Option";
 import {
+  AmountInEuroCents,
   PaymentNoticeNumberFromString,
   RptId
 } from "italia-ts-commons/lib/pagopa";
@@ -16,7 +17,10 @@ import { Body, Container, Content, Left, Right, Text, View } from "native-base";
 import * as React from "react";
 import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
+
+import { CodiceContestoPagamento } from "../../../../definitions/backend/CodiceContestoPagamento";
 import { EnteBeneficiario } from "../../../../definitions/backend/EnteBeneficiario";
+
 import GoBackButton from "../../../components/GoBackButton";
 import { withErrorModal } from "../../../components/helpers/withErrorModal";
 import { withLoadingSpinner } from "../../../components/helpers/withLoadingSpinner";
@@ -25,7 +29,9 @@ import AppHeader from "../../../components/ui/AppHeader";
 import FooterWithButtons from "../../../components/ui/FooterWithButtons";
 import Markdown from "../../../components/ui/Markdown";
 import PaymentSummaryComponent from "../../../components/wallet/PaymentSummaryComponent";
+
 import I18n from "../../../i18n";
+
 import { Dispatch } from "../../../store/actions/types";
 import {
   paymentRequestCancel,
@@ -36,17 +42,30 @@ import { createErrorSelector } from "../../../store/reducers/error";
 import { createLoadingSelector } from "../../../store/reducers/loading";
 import { GlobalState } from "../../../store/reducers/types";
 import {
+  getCurrentAmountFromGlobalStateWithVerificaResponse,
+  getInitialAmountFromGlobalStateWithVerificaResponse,
+  getPaymentContextCodeFromGlobalStateWithVerificaResponse,
   getPaymentReason,
-  getPaymentRecipient,
+  getPaymentRecipientFromGlobalStateWithVerificaResponse,
   getPaymentStep,
-  getRptId,
+  getRptIdFromGlobalStateWithVerificaResponse,
   isGlobalStateWithVerificaResponse
 } from "../../../store/reducers/wallet/payment";
+
 import { mapErrorCodeToMessage } from "../../../types/errors";
 import {
   UNKNOWN_PAYMENT_REASON,
   UNKNOWN_RECIPIENT
 } from "../../../types/unknown";
+
+type TransactionInfo = Readonly<{
+  paymentReason: string;
+  paymentRecipient: EnteBeneficiario;
+  rptId: RptId;
+  codiceContestoPagamento: CodiceContestoPagamento;
+  amount: AmountInEuroCents;
+  currentAmount: AmountInEuroCents;
+}>;
 
 type ReduxMappedStateProps = Readonly<{
   error: Option<string>;
@@ -58,13 +77,15 @@ type ReduxMappedStateProps = Readonly<{
       }>
     | Readonly<{
         valid: true;
-        paymentReason: string | undefined;
-        paymentRecipient: EnteBeneficiario | undefined;
-        rptId: RptId | undefined;
+        transactionInfo: Option<TransactionInfo>;
       }>);
 
 type ReduxMappedDispatchProps = Readonly<{
-  confirmSummary: () => void;
+  confirmSummary: (
+    rptId: RptId,
+    codiceContestoPagamento: CodiceContestoPagamento,
+    currentAmount: AmountInEuroCents
+  ) => void;
   goBack: () => void;
   cancelPayment: () => void;
   onCancel: () => void;
@@ -109,10 +130,21 @@ class TransactionSummaryScreen extends React.Component<Props, never> {
       return null;
     }
 
+    // when empty, it means we're still loading the verifica response
+    const txInfo = this.props.transactionInfo;
+
     const primaryButtonProps = {
+      disabled: txInfo.isNone(),
       block: true,
       primary: true,
-      onPress: () => this.props.confirmSummary(),
+      onPress: txInfo.isSome()
+        ? () =>
+            this.props.confirmSummary(
+              txInfo.value.rptId,
+              txInfo.value.codiceContestoPagamento,
+              txInfo.value.currentAmount
+            )
+        : undefined,
       title: I18n.t("wallet.continue")
     };
 
@@ -122,8 +154,6 @@ class TransactionSummaryScreen extends React.Component<Props, never> {
       onPress: () => this.props.cancelPayment(),
       title: I18n.t("wallet.cancel")
     };
-
-    const { paymentRecipient, paymentReason, rptId } = this.props;
 
     return (
       <Container>
@@ -140,22 +170,36 @@ class TransactionSummaryScreen extends React.Component<Props, never> {
         </AppHeader>
 
         <Content noPadded={true}>
-          <PaymentSummaryComponent navigation={this.props.navigation} />
+          {txInfo.isSome() ? (
+            <PaymentSummaryComponent
+              navigation={this.props.navigation}
+              hasVerificaResponse={true}
+              amount={txInfo.value.amount}
+              updatedAmount={txInfo.value.currentAmount}
+              paymentReason={txInfo.value.paymentReason}
+            />
+          ) : (
+            <PaymentSummaryComponent
+              navigation={this.props.navigation}
+              hasVerificaResponse={false}
+            />
+          )}
+
           <View content={true}>
             <Markdown>
-              {paymentRecipient !== undefined
-                ? formatMdRecipient(paymentRecipient)
-                : "..."}
+              {txInfo
+                .map(_ => formatMdRecipient(_.paymentRecipient))
+                .getOrElse("...")}
             </Markdown>
             <View spacer={true} />
             <Markdown>
-              {paymentReason !== undefined
-                ? formatMdPaymentReason(paymentReason)
-                : "..."}
+              {txInfo
+                .map(_ => formatMdPaymentReason(_.paymentReason))
+                .getOrElse("...")}
             </Markdown>
             <View spacer={true} />
             <Markdown>
-              {rptId !== undefined ? formatMdInfoRpt(rptId) : "..."}
+              {txInfo.map(_ => formatMdInfoRpt(_.rptId)).getOrElse("...")}
             </Markdown>
             <View spacer={true} />
           </View>
@@ -170,48 +214,78 @@ class TransactionSummaryScreen extends React.Component<Props, never> {
   }
 }
 
-const mapStateToProps = (state: GlobalState): ReduxMappedStateProps => ({
-  error: createErrorSelector(["PAYMENT"])(state),
-  isLoading: createLoadingSelector(["PAYMENT"])(state),
-  ...((getPaymentStep(state) === "PaymentStateSummary" ||
-    getPaymentStep(state) === "PaymentStateSummaryWithPaymentId") &&
-  isGlobalStateWithVerificaResponse(state)
-    ? {
-        valid: true,
+function mapStateToProps() {
+  const paymentErrorSelector = createErrorSelector(["PAYMENT"]);
+  const paymentLoadingSelector = createLoadingSelector(["PAYMENT"]);
+
+  return (state: GlobalState): ReduxMappedStateProps => {
+    if (
+      (getPaymentStep(state) === "PaymentStateSummary" ||
+        getPaymentStep(state) === "PaymentStateSummaryWithPaymentId") &&
+      isGlobalStateWithVerificaResponse(state)
+    ) {
+      const transactionInfo = some({
         paymentReason: getPaymentReason(state).getOrElse(
           UNKNOWN_PAYMENT_REASON
         ), // could be undefined as per pagoPA type definition
-        paymentRecipient: getPaymentRecipient(state).getOrElse(
-          UNKNOWN_RECIPIENT
-        ), // could be undefined as per pagoPA type definition
-        rptId: getRptId(state)
-      }
-    : getPaymentStep(state) === "PaymentStateNoState" ||
+        paymentRecipient: getPaymentRecipientFromGlobalStateWithVerificaResponse(
+          state
+        ).getOrElse(UNKNOWN_RECIPIENT), // could be undefined as per pagoPA type definition
+        rptId: getRptIdFromGlobalStateWithVerificaResponse(state),
+        codiceContestoPagamento: getPaymentContextCodeFromGlobalStateWithVerificaResponse(
+          state
+        ),
+        amount: getInitialAmountFromGlobalStateWithVerificaResponse(state),
+        currentAmount: getCurrentAmountFromGlobalStateWithVerificaResponse(
+          state
+        )
+      });
+      return {
+        valid: true,
+        error: paymentErrorSelector(state),
+        isLoading: paymentLoadingSelector(state),
+        transactionInfo
+      };
+    } else if (
+      getPaymentStep(state) === "PaymentStateNoState" ||
       getPaymentStep(state) === "PaymentStateQrCode" ||
       getPaymentStep(state) === "PaymentStateManualEntry"
-      ? {
-          valid: true,
-          error: createErrorSelector(["PAYMENT"])(state),
-          isLoading: createLoadingSelector(["PAYMENT"])(state),
-          paymentReason: undefined,
-          paymentRecipient: undefined,
-          rptId: undefined
-        }
-      : {
-          valid: false,
-          error: createErrorSelector(["PAYMENT"])(state),
-          isLoading: createLoadingSelector(["PAYMENT"])(state)
-        })
-});
+    ) {
+      return {
+        valid: true,
+        error: paymentErrorSelector(state),
+        isLoading: paymentLoadingSelector(state),
+        transactionInfo: none
+      };
+    } else {
+      return {
+        valid: false,
+        error: paymentErrorSelector(state),
+        isLoading: paymentLoadingSelector(state)
+      };
+    }
+  };
+}
 const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedDispatchProps => ({
-  confirmSummary: () => dispatch(paymentRequestContinueWithPaymentMethods()),
+  confirmSummary: (
+    rptId: RptId,
+    codiceContestoPagamento: CodiceContestoPagamento,
+    currentAmount: AmountInEuroCents
+  ) =>
+    dispatch(
+      paymentRequestContinueWithPaymentMethods({
+        rptId,
+        codiceContestoPagamento,
+        currentAmount
+      })
+    ),
   goBack: () => dispatch(paymentRequestGoBack()),
   cancelPayment: () => dispatch(paymentRequestCancel()),
   onCancel: () => dispatch(paymentRequestCancel())
 });
 
 export default connect(
-  mapStateToProps,
+  mapStateToProps(),
   mapDispatchToProps
 )(
   withErrorModal(

--- a/ts/store/actions/wallet/payment.ts
+++ b/ts/store/actions/wallet/payment.ts
@@ -83,15 +83,15 @@ export const paymentRequestContinueWithPaymentMethods = createStandardAction(
   "PAYMENT_REQUEST_CONTINUE_WITH_PAYMENT_METHODS"
 )<PaymentRequestContinueWithPaymentMethodsPayload>();
 
+type PaymentRequestPickPaymentMethodPayload = Readonly<{
+  paymentId: string;
+}>;
+
 export const paymentRequestPickPaymentMethod = createStandardAction(
   "PAYMENT_REQUEST_PICK_PAYMENT_METHOD"
-)();
+)<PaymentRequestPickPaymentMethodPayload>();
 
 export const setPaymentStateToPickPaymentMethod = createStandardAction(
-  "PAYMENT_PICK_PAYMENT_METHOD"
-)();
-
-export const setPaymentStateFromSummaryToPickPaymentMethod = createStandardAction(
   "PAYMENT_INITIAL_PICK_PAYMENT_METHOD"
 )<string>();
 
@@ -205,7 +205,6 @@ export type PaymentActions =
   | ActionType<typeof paymentRequestContinueWithPaymentMethods>
   | ActionType<typeof paymentRequestPickPaymentMethod>
   | ActionType<typeof setPaymentStateToPickPaymentMethod>
-  | ActionType<typeof setPaymentStateFromSummaryToPickPaymentMethod>
   | ActionType<typeof paymentRequestConfirmPaymentMethod>
   | ActionType<typeof setPaymentStateToConfirmPaymentMethod>
   | ActionType<typeof setPaymentStateFromSummaryToConfirmPaymentMethod>

--- a/ts/store/actions/wallet/payment.ts
+++ b/ts/store/actions/wallet/payment.ts
@@ -4,9 +4,12 @@ import {
   createAction,
   createStandardAction
 } from "typesafe-actions";
+
+import { CodiceContestoPagamento } from "../../../../definitions/backend/CodiceContestoPagamento";
 import { PaymentRequestsGetResponse } from "../../../../definitions/backend/PaymentRequestsGetResponse";
+
 import { PagoPaErrors } from "../../../types/errors";
-import { Psp } from "../../../types/pagopa";
+import { Psp, Wallet } from "../../../types/pagopa";
 
 export const resetPaymentState = createStandardAction("PAYMENT_COMPLETED")();
 
@@ -70,9 +73,15 @@ export const setPaymentStateToSummaryWithPaymentId = createStandardAction(
   "PAYMENT_TRANSACTION_SUMMARY_FROM_BANNER"
 )();
 
+type PaymentRequestContinueWithPaymentMethodsPayload = Readonly<{
+  rptId: RptId;
+  codiceContestoPagamento: CodiceContestoPagamento;
+  currentAmount: AmountInEuroCents;
+}>;
+
 export const paymentRequestContinueWithPaymentMethods = createStandardAction(
   "PAYMENT_REQUEST_CONTINUE_WITH_PAYMENT_METHODS"
-)();
+)<PaymentRequestContinueWithPaymentMethodsPayload>();
 
 export const paymentRequestPickPaymentMethod = createStandardAction(
   "PAYMENT_REQUEST_PICK_PAYMENT_METHOD"
@@ -86,51 +95,66 @@ export const setPaymentStateFromSummaryToPickPaymentMethod = createStandardActio
   "PAYMENT_INITIAL_PICK_PAYMENT_METHOD"
 )<string>();
 
+type PaymentRequestConfirmPaymentMethodPayload = Readonly<{
+  wallet: Wallet;
+  paymentId: string;
+}>;
+
 export const paymentRequestConfirmPaymentMethod = createStandardAction(
   "PAYMENT_REQUEST_CONFIRM_PAYMENT_METHOD"
-)<number>();
+)<PaymentRequestConfirmPaymentMethodPayload>();
 
 export const setPaymentStateToConfirmPaymentMethod = createAction(
   "PAYMENT_CONFIRM_PAYMENT_METHOD",
-  resolve => (walletId: number, pspList: ReadonlyArray<Psp>) =>
-    resolve({ selectedPaymentMethod: walletId, pspList })
+  resolve => (wallet: Wallet, pspList: ReadonlyArray<Psp>) =>
+    resolve({ selectedPaymentMethod: wallet, pspList })
 );
 
 export const setPaymentStateFromSummaryToConfirmPaymentMethod = createAction(
   "PAYMENT_INITIAL_CONFIRM_PAYMENT_METHOD",
-  resolve => (
-    walletId: number,
-    pspList: ReadonlyArray<Psp>,
-    paymentId: string
-  ) => resolve({ selectedPaymentMethod: walletId, pspList, paymentId })
+  resolve => (wallet: Wallet, pspList: ReadonlyArray<Psp>, paymentId: string) =>
+    resolve({ selectedPaymentMethod: wallet, pspList, paymentId })
 );
+
+type PaymentRequestPickPspPayload = Readonly<{
+  wallet: Wallet;
+  pspList: ReadonlyArray<Psp>;
+}>;
 
 export const paymentRequestPickPsp = createStandardAction(
   "PAYMENT_REQUEST_PICK_PSP"
-)();
+)<PaymentRequestPickPspPayload>();
 
 export const setPaymentStateFromSummaryToPickPsp = createAction(
   "PAYMENT_INITIAL_PICK_PSP",
-  resolve => (
-    walletId: number,
-    pspList: ReadonlyArray<Psp>,
-    paymentId: string
-  ) => resolve({ selectedPaymentMethod: walletId, pspList, paymentId })
+  resolve => (wallet: Wallet, pspList: ReadonlyArray<Psp>, paymentId: string) =>
+    resolve({ selectedPaymentMethod: wallet, pspList, paymentId })
 );
 
 export const setPaymentStateToPickPsp = createAction(
   "PAYMENT_PICK_PSP",
-  resolve => (walletId: number, pspList: ReadonlyArray<Psp>) =>
-    resolve({ selectedPaymentMethod: walletId, pspList })
+  resolve => (wallet: Wallet, pspList: ReadonlyArray<Psp>) =>
+    resolve({ selectedPaymentMethod: wallet, pspList })
 );
 
+type PaymentUpdatePspPayload = Readonly<{
+  pspId: number;
+  wallet: Wallet;
+  paymentId: string;
+}>;
+
 export const paymentUpdatePsp = createStandardAction("PAYMENT_UPDATE_PSP")<
-  number
+  PaymentUpdatePspPayload
 >();
+
+type PaymentRequestCompletionPayload = Readonly<{
+  wallet: Wallet;
+  paymentId: string;
+}>;
 
 export const paymentRequestCompletion = createStandardAction(
   "PAYMENT_REQUEST_COMPLETION"
-)();
+)<PaymentRequestCompletionPayload>();
 
 export const goBackOnePaymentState = createStandardAction("PAYMENT_GO_BACK")();
 
@@ -152,9 +176,14 @@ export const paymentRequestCancel = createStandardAction(
   "PAYMENT_REQUEST_CANCEL"
 )();
 
+type PaymentRequestPinLoginPayload = Readonly<{
+  wallet: Wallet;
+  paymentId: string;
+}>;
+
 export const paymentRequestPinLogin = createStandardAction(
   "PAYMENT_REQUEST_PIN_LOGIN"
-)();
+)<PaymentRequestPinLoginPayload>();
 
 export const setPaymentStateToPinLogin = createStandardAction(
   "PAYMENT_PIN_LOGIN"

--- a/ts/store/actions/wallet/payment.ts
+++ b/ts/store/actions/wallet/payment.ts
@@ -32,10 +32,6 @@ export const setPaymentStateToQrCode = createStandardAction(
   "PAYMENT_QR_CODE"
 )();
 
-export const paymentRequestManualEntry = createStandardAction(
-  "PAYMENT_REQUEST_MANUAL_ENTRY"
-)();
-
 export const paymentRequestMessage = createStandardAction(
   "PAYMENT_REQUEST_MESSAGE"
 )();
@@ -180,7 +176,6 @@ export const paymentFailure = createStandardAction("PAYMENT_FAILURE")<
 export type PaymentActions =
   | ActionType<typeof paymentRequestQrCode>
   | ActionType<typeof setPaymentStateToQrCode>
-  | ActionType<typeof paymentRequestManualEntry>
   | ActionType<typeof paymentRequestMessage>
   | ActionType<typeof setPaymentStateToManualEntry>
   | ActionType<typeof paymentRequestTransactionSummaryFromBanner>

--- a/ts/store/actions/wallet/payment.ts
+++ b/ts/store/actions/wallet/payment.ts
@@ -119,22 +119,17 @@ export const setPaymentStateFromSummaryToConfirmPaymentMethod = createAction(
 type PaymentRequestPickPspPayload = Readonly<{
   wallet: Wallet;
   pspList: ReadonlyArray<Psp>;
+  paymentId: string;
 }>;
 
 export const paymentRequestPickPsp = createStandardAction(
   "PAYMENT_REQUEST_PICK_PSP"
 )<PaymentRequestPickPspPayload>();
 
-export const setPaymentStateFromSummaryToPickPsp = createAction(
-  "PAYMENT_INITIAL_PICK_PSP",
-  resolve => (wallet: Wallet, pspList: ReadonlyArray<Psp>, paymentId: string) =>
-    resolve({ selectedPaymentMethod: wallet, pspList, paymentId })
-);
-
 export const setPaymentStateToPickPsp = createAction(
   "PAYMENT_PICK_PSP",
-  resolve => (wallet: Wallet, pspList: ReadonlyArray<Psp>) =>
-    resolve({ selectedPaymentMethod: wallet, pspList })
+  resolve => (wallet: Wallet, pspList: ReadonlyArray<Psp>, paymentId: string) =>
+    resolve({ selectedPaymentMethod: wallet, pspList, paymentId })
 );
 
 type PaymentUpdatePspPayload = Readonly<{
@@ -210,7 +205,6 @@ export type PaymentActions =
   | ActionType<typeof setPaymentStateFromSummaryToConfirmPaymentMethod>
   | ActionType<typeof paymentRequestPickPsp>
   | ActionType<typeof setPaymentStateToPickPsp>
-  | ActionType<typeof setPaymentStateFromSummaryToPickPsp>
   | ActionType<typeof paymentUpdatePsp>
   | ActionType<typeof paymentUpdatePspInState> // TODO: temporary, until integration with pagoPA occurs @https://www.pivotaltracker.com/story/show/159494746
   | ActionType<typeof paymentRequestCompletion>

--- a/ts/store/actions/wallet/payment.ts
+++ b/ts/store/actions/wallet/payment.ts
@@ -105,12 +105,6 @@ export const paymentRequestConfirmPaymentMethod = createStandardAction(
 )<PaymentRequestConfirmPaymentMethodPayload>();
 
 export const setPaymentStateToConfirmPaymentMethod = createAction(
-  "PAYMENT_CONFIRM_PAYMENT_METHOD",
-  resolve => (wallet: Wallet, pspList: ReadonlyArray<Psp>) =>
-    resolve({ selectedPaymentMethod: wallet, pspList })
-);
-
-export const setPaymentStateFromSummaryToConfirmPaymentMethod = createAction(
   "PAYMENT_INITIAL_CONFIRM_PAYMENT_METHOD",
   resolve => (wallet: Wallet, pspList: ReadonlyArray<Psp>, paymentId: string) =>
     resolve({ selectedPaymentMethod: wallet, pspList, paymentId })
@@ -202,7 +196,6 @@ export type PaymentActions =
   | ActionType<typeof setPaymentStateToPickPaymentMethod>
   | ActionType<typeof paymentRequestConfirmPaymentMethod>
   | ActionType<typeof setPaymentStateToConfirmPaymentMethod>
-  | ActionType<typeof setPaymentStateFromSummaryToConfirmPaymentMethod>
   | ActionType<typeof paymentRequestPickPsp>
   | ActionType<typeof setPaymentStateToPickPsp>
   | ActionType<typeof paymentUpdatePsp>

--- a/ts/store/actions/wallet/payment.ts
+++ b/ts/store/actions/wallet/payment.ts
@@ -21,19 +21,13 @@ export const paymentUpdatePspInState = createStandardAction(
   "PAYMENT_UPDATE_PSP_IN_STATE"
 )<PaymentUpdatePspInStatePayload>();
 
-export const paymentRequestQrCode = createStandardAction(
-  "PAYMENT_REQUEST_QR_CODE"
-)();
+export const startPaymentSaga = createStandardAction("PAYMENT_REQUEST")();
 
 /**
  * Sets the payment state to PaymentStateQrCode, only if previous state is none
  */
 export const setPaymentStateToQrCode = createStandardAction(
   "PAYMENT_QR_CODE"
-)();
-
-export const paymentRequestMessage = createStandardAction(
-  "PAYMENT_REQUEST_MESSAGE"
 )();
 
 /**
@@ -174,9 +168,8 @@ export const paymentFailure = createStandardAction("PAYMENT_FAILURE")<
  * All possible payment actions
  */
 export type PaymentActions =
-  | ActionType<typeof paymentRequestQrCode>
+  | ActionType<typeof startPaymentSaga>
   | ActionType<typeof setPaymentStateToQrCode>
-  | ActionType<typeof paymentRequestMessage>
   | ActionType<typeof setPaymentStateToManualEntry>
   | ActionType<typeof paymentRequestTransactionSummaryFromBanner>
   | ActionType<typeof paymentRequestTransactionSummaryFromRptId>

--- a/ts/store/actions/wallet/payment.ts
+++ b/ts/store/actions/wallet/payment.ts
@@ -8,7 +8,7 @@ import { PaymentRequestsGetResponse } from "../../../../definitions/backend/Paym
 import { PagoPaErrors } from "../../../types/errors";
 import { Psp } from "../../../types/pagopa";
 
-export const paymentCompleted = createStandardAction("PAYMENT_COMPLETED")();
+export const resetPaymentState = createStandardAction("PAYMENT_COMPLETED")();
 
 type PaymentUpdatePspInStatePayload = Readonly<{
   walletId: number;
@@ -25,7 +25,12 @@ export const paymentRequestQrCode = createStandardAction(
   "PAYMENT_REQUEST_QR_CODE"
 )();
 
-export const paymentQrCode = createStandardAction("PAYMENT_QR_CODE")();
+/**
+ * Sets the payment state to PaymentStateQrCode, only if previous state is none
+ */
+export const setPaymentStateToQrCode = createStandardAction(
+  "PAYMENT_QR_CODE"
+)();
 
 export const paymentRequestManualEntry = createStandardAction(
   "PAYMENT_REQUEST_MANUAL_ENTRY"
@@ -35,7 +40,11 @@ export const paymentRequestMessage = createStandardAction(
   "PAYMENT_REQUEST_MESSAGE"
 )();
 
-export const paymentManualEntry = createStandardAction(
+/**
+ * Sets the payment state to PaymentStateManualEntry, only if previous state is
+ * PaymentStateQrCode.
+ */
+export const setPaymentStateToManualEntry = createStandardAction(
   "PAYMENT_MANUAL_ENTRY"
 )();
 
@@ -56,7 +65,7 @@ export const paymentRequestTransactionSummaryFromBanner = createStandardAction(
 
 // For when the user taps on the payment banner and gets redirected
 // to the summary of the payment.
-export const paymentTransactionSummaryFromRptId = createAction(
+export const setPaymentStateToSummary = createAction(
   "PAYMENT_TRANSACTION_SUMMARY_FROM_RPT_ID",
   resolve => (
     rptId: RptId,
@@ -67,7 +76,7 @@ export const paymentTransactionSummaryFromRptId = createAction(
 
 // for when the user taps on the payment banner and gets redirected
 // to the summary of the payment
-export const paymentTransactionSummaryFromBanner = createStandardAction(
+export const setPaymentStateToSummaryWithPaymentId = createStandardAction(
   "PAYMENT_TRANSACTION_SUMMARY_FROM_BANNER"
 )();
 
@@ -79,11 +88,11 @@ export const paymentRequestPickPaymentMethod = createStandardAction(
   "PAYMENT_REQUEST_PICK_PAYMENT_METHOD"
 )();
 
-export const paymentPickPaymentMethod = createStandardAction(
+export const setPaymentStateToPickPaymentMethod = createStandardAction(
   "PAYMENT_PICK_PAYMENT_METHOD"
 )();
 
-export const paymentInitialPickPaymentMethod = createStandardAction(
+export const setPaymentStateFromSummaryToPickPaymentMethod = createStandardAction(
   "PAYMENT_INITIAL_PICK_PAYMENT_METHOD"
 )<string>();
 
@@ -91,13 +100,13 @@ export const paymentRequestConfirmPaymentMethod = createStandardAction(
   "PAYMENT_REQUEST_CONFIRM_PAYMENT_METHOD"
 )<number>();
 
-export const paymentConfirmPaymentMethod = createAction(
+export const setPaymentStateToConfirmPaymentMethod = createAction(
   "PAYMENT_CONFIRM_PAYMENT_METHOD",
   resolve => (walletId: number, pspList: ReadonlyArray<Psp>) =>
     resolve({ selectedPaymentMethod: walletId, pspList })
 );
 
-export const paymentInitialConfirmPaymentMethod = createAction(
+export const setPaymentStateFromSummaryToConfirmPaymentMethod = createAction(
   "PAYMENT_INITIAL_CONFIRM_PAYMENT_METHOD",
   resolve => (
     walletId: number,
@@ -110,7 +119,7 @@ export const paymentRequestPickPsp = createStandardAction(
   "PAYMENT_REQUEST_PICK_PSP"
 )();
 
-export const paymentInitialPickPsp = createAction(
+export const setPaymentStateFromSummaryToPickPsp = createAction(
   "PAYMENT_INITIAL_PICK_PSP",
   resolve => (
     walletId: number,
@@ -119,7 +128,7 @@ export const paymentInitialPickPsp = createAction(
   ) => resolve({ selectedPaymentMethod: walletId, pspList, paymentId })
 );
 
-export const paymentPickPsp = createAction(
+export const setPaymentStateToPickPsp = createAction(
   "PAYMENT_PICK_PSP",
   resolve => (walletId: number, pspList: ReadonlyArray<Psp>) =>
     resolve({ selectedPaymentMethod: walletId, pspList })
@@ -133,7 +142,7 @@ export const paymentRequestCompletion = createStandardAction(
   "PAYMENT_REQUEST_COMPLETION"
 )();
 
-export const paymentGoBack = createStandardAction("PAYMENT_GO_BACK")();
+export const goBackOnePaymentState = createStandardAction("PAYMENT_GO_BACK")();
 
 export const paymentRequestGoBack = createStandardAction(
   "PAYMENT_REQUEST_GO_BACK"
@@ -157,7 +166,9 @@ export const paymentRequestPinLogin = createStandardAction(
   "PAYMENT_REQUEST_PIN_LOGIN"
 )();
 
-export const paymentPinLogin = createStandardAction("PAYMENT_PIN_LOGIN")();
+export const setPaymentStateToPinLogin = createStandardAction(
+  "PAYMENT_PIN_LOGIN"
+)();
 
 export const paymentFailure = createStandardAction("PAYMENT_FAILURE")<
   PagoPaErrors
@@ -168,32 +179,32 @@ export const paymentFailure = createStandardAction("PAYMENT_FAILURE")<
  */
 export type PaymentActions =
   | ActionType<typeof paymentRequestQrCode>
-  | ActionType<typeof paymentQrCode>
+  | ActionType<typeof setPaymentStateToQrCode>
   | ActionType<typeof paymentRequestManualEntry>
   | ActionType<typeof paymentRequestMessage>
-  | ActionType<typeof paymentManualEntry>
+  | ActionType<typeof setPaymentStateToManualEntry>
   | ActionType<typeof paymentRequestTransactionSummaryFromBanner>
   | ActionType<typeof paymentRequestTransactionSummaryFromRptId>
   | ActionType<typeof paymentRequestContinueWithPaymentMethods>
   | ActionType<typeof paymentRequestPickPaymentMethod>
-  | ActionType<typeof paymentPickPaymentMethod>
-  | ActionType<typeof paymentInitialPickPaymentMethod>
+  | ActionType<typeof setPaymentStateToPickPaymentMethod>
+  | ActionType<typeof setPaymentStateFromSummaryToPickPaymentMethod>
   | ActionType<typeof paymentRequestConfirmPaymentMethod>
-  | ActionType<typeof paymentConfirmPaymentMethod>
-  | ActionType<typeof paymentInitialConfirmPaymentMethod>
+  | ActionType<typeof setPaymentStateToConfirmPaymentMethod>
+  | ActionType<typeof setPaymentStateFromSummaryToConfirmPaymentMethod>
   | ActionType<typeof paymentRequestPickPsp>
-  | ActionType<typeof paymentPickPsp>
-  | ActionType<typeof paymentInitialPickPsp>
+  | ActionType<typeof setPaymentStateToPickPsp>
+  | ActionType<typeof setPaymentStateFromSummaryToPickPsp>
   | ActionType<typeof paymentUpdatePsp>
   | ActionType<typeof paymentUpdatePspInState> // TODO: temporary, until integration with pagoPA occurs @https://www.pivotaltracker.com/story/show/159494746
   | ActionType<typeof paymentRequestCompletion>
-  | ActionType<typeof paymentCompleted>
-  | ActionType<typeof paymentGoBack>
+  | ActionType<typeof resetPaymentState>
+  | ActionType<typeof goBackOnePaymentState>
   | ActionType<typeof paymentRequestGoBack>
   | ActionType<typeof paymentSetLoadingState>
   | ActionType<typeof paymentResetLoadingState>
   | ActionType<typeof paymentCancel>
   | ActionType<typeof paymentRequestCancel>
   | ActionType<typeof paymentRequestPinLogin>
-  | ActionType<typeof paymentPinLogin>
+  | ActionType<typeof setPaymentStateToPinLogin>
   | ActionType<typeof paymentFailure>;

--- a/ts/store/actions/wallet/wallets.ts
+++ b/ts/store/actions/wallet/wallets.ts
@@ -35,10 +35,9 @@ export const fetchWalletsFailure = createAction(
   resolve => (error: Error) => resolve(error)
 );
 
-export const selectWalletForDetails = createAction(
-  "SELECT_WALLET_FOR_DETAILS",
-  resolve => (walletId: number) => resolve(walletId)
-);
+export const selectWalletForDetails = createStandardAction(
+  "SELECT_WALLET_FOR_DETAILS"
+)<number>();
 
 export const setFavoriteWallet = createAction(
   "SET_FAVORITE_WALLET",

--- a/ts/store/reducers/wallet/payment.ts
+++ b/ts/store/reducers/wallet/payment.ts
@@ -19,7 +19,6 @@ import {
   paymentCancel,
   resetPaymentState,
   setPaymentStateFromSummaryToConfirmPaymentMethod,
-  setPaymentStateFromSummaryToPickPaymentMethod,
   setPaymentStateFromSummaryToPickPsp,
   setPaymentStateToConfirmPaymentMethod,
   setPaymentStateToManualEntry,
@@ -488,11 +487,11 @@ const pickMethodReducer: PaymentReducer = (
   action: Action
 ) => {
   if (
-    isActionOf(setPaymentStateFromSummaryToPickPaymentMethod, action) &&
+    isActionOf(setPaymentStateToPickPaymentMethod, action) &&
     isInAllowedOrigins(state, [
-      "PaymentStateSummary"
-      // "PaymentStateSummaryWithPaymentId",
-      // "PaymentStateConfirmPaymentMethod"
+      "PaymentStateSummary",
+      "PaymentStateSummaryWithPaymentId",
+      "PaymentStateConfirmPaymentMethod"
     ]) &&
     isPaymentStateWithVerificaResponse(state)
   ) {
@@ -513,29 +512,7 @@ const pickMethodReducer: PaymentReducer = (
       )
     };
   }
-  if (
-    isActionOf(setPaymentStateToPickPaymentMethod, action) &&
-    isInAllowedOrigins(state, [
-      "PaymentStateSummaryWithPaymentId",
-      "PaymentStateConfirmPaymentMethod"
-    ]) &&
-    isPaymentStateWithPaymentId(state)
-  ) {
-    const prevState = state.stack.head;
-    return {
-      stack: popToStateAndPush(
-        state.stack,
-        {
-          kind: "PaymentStatePickPaymentMethod",
-          rptId: prevState.rptId,
-          verificaResponse: prevState.verificaResponse,
-          initialAmount: prevState.initialAmount,
-          paymentId: prevState.paymentId
-        },
-        ["PaymentStatePickPaymentMethod"]
-      )
-    };
-  }
+
   return state;
 };
 

--- a/ts/store/reducers/wallet/payment.ts
+++ b/ts/store/reducers/wallet/payment.ts
@@ -19,7 +19,6 @@ import {
   paymentCancel,
   resetPaymentState,
   setPaymentStateFromSummaryToConfirmPaymentMethod,
-  setPaymentStateFromSummaryToPickPsp,
   setPaymentStateToConfirmPaymentMethod,
   setPaymentStateToManualEntry,
   setPaymentStateToPickPaymentMethod,
@@ -572,25 +571,9 @@ const pickPspReducer: PaymentReducer = (
   action: Action
 ) => {
   if (
-    isActionOf(setPaymentStateFromSummaryToPickPsp, action) &&
-    isInAllowedOrigins(state, ["PaymentStateSummary"]) &&
-    isPaymentStateWithVerificaResponse(state)
-  ) {
-    return {
-      stack: popToStateAndPush(
-        state.stack,
-        {
-          ...state.stack.head,
-          ...action.payload,
-          kind: "PaymentStatePickPsp"
-        },
-        ["PaymentStatePickPsp"]
-      )
-    };
-  }
-  if (
     isActionOf(setPaymentStateToPickPsp, action) &&
     isInAllowedOrigins(state, [
+      "PaymentStateSummary",
       "PaymentStateSummaryWithPaymentId",
       "PaymentStateConfirmPaymentMethod",
       "PaymentStatePickPaymentMethod"

--- a/ts/store/reducers/wallet/payment.ts
+++ b/ts/store/reducers/wallet/payment.ts
@@ -18,7 +18,6 @@ import {
   goBackOnePaymentState,
   paymentCancel,
   resetPaymentState,
-  setPaymentStateFromSummaryToConfirmPaymentMethod,
   setPaymentStateToConfirmPaymentMethod,
   setPaymentStateToManualEntry,
   setPaymentStateToPickPaymentMethod,
@@ -523,30 +522,14 @@ const confirmMethodReducer: PaymentReducer = (
   action: Action
 ) => {
   if (
-    isActionOf(setPaymentStateFromSummaryToConfirmPaymentMethod, action) &&
-    isInAllowedOrigins(state, ["PaymentStateSummary"]) &&
-    isPaymentStateWithVerificaResponse(state)
-  ) {
-    return {
-      stack: popToStateAndPush(
-        state.stack,
-        {
-          ...state.stack.head,
-          ...action.payload,
-          kind: "PaymentStateConfirmPaymentMethod"
-        },
-        ["PaymentStateConfirmPaymentMethod"]
-      )
-    };
-  }
-  if (
     isActionOf(setPaymentStateToConfirmPaymentMethod, action) &&
     isInAllowedOrigins(state, [
+      "PaymentStateSummary",
       "PaymentStatePickPaymentMethod",
       "PaymentStateSummaryWithPaymentId",
       "PaymentStatePickPsp"
     ]) &&
-    isPaymentStateWithPaymentId(state)
+    isPaymentStateWithVerificaResponse(state)
   ) {
     return {
       stack: popToStateAndPush(

--- a/ts/store/reducers/wallet/payment.ts
+++ b/ts/store/reducers/wallet/payment.ts
@@ -17,20 +17,20 @@ import { UNKNOWN_CARD } from "../../../types/unknown";
 import { AmountToImporto } from "../../../utils/amounts";
 import { Action } from "../../actions/types";
 import {
+  goBackOnePaymentState,
   paymentCancel,
-  paymentCompleted,
-  paymentConfirmPaymentMethod,
-  paymentGoBack,
-  paymentInitialConfirmPaymentMethod,
-  paymentInitialPickPaymentMethod,
-  paymentInitialPickPsp,
-  paymentManualEntry,
-  paymentPickPaymentMethod,
-  paymentPickPsp,
-  paymentPinLogin,
-  paymentQrCode,
-  paymentTransactionSummaryFromBanner,
-  paymentTransactionSummaryFromRptId
+  resetPaymentState,
+  setPaymentStateFromSummaryToConfirmPaymentMethod,
+  setPaymentStateFromSummaryToPickPaymentMethod,
+  setPaymentStateFromSummaryToPickPsp,
+  setPaymentStateToConfirmPaymentMethod,
+  setPaymentStateToManualEntry,
+  setPaymentStateToPickPaymentMethod,
+  setPaymentStateToPickPsp,
+  setPaymentStateToPinLogin,
+  setPaymentStateToQrCode,
+  setPaymentStateToSummary,
+  setPaymentStateToSummaryWithPaymentId
 } from "../../actions/wallet/payment";
 import { IndexedById } from "../../helpers/indexer";
 import {
@@ -341,7 +341,7 @@ const dataEntryReducer: PaymentReducer = (
   action: Action
 ) => {
   if (
-    isActionOf(paymentQrCode, action) &&
+    isActionOf(setPaymentStateToQrCode, action) &&
     isInAllowedOrigins(state, ["none"])
   ) {
     return {
@@ -355,7 +355,7 @@ const dataEntryReducer: PaymentReducer = (
     };
   }
   if (
-    isActionOf(paymentManualEntry, action) &&
+    isActionOf(setPaymentStateToManualEntry, action) &&
     isInAllowedOrigins(state, ["PaymentStateQrCode"])
   ) {
     return {
@@ -379,7 +379,7 @@ const summaryReducer: PaymentReducer = (
   action: Action
 ) => {
   if (
-    isActionOf(paymentTransactionSummaryFromRptId, action) &&
+    isActionOf(setPaymentStateToSummary, action) &&
     isInAllowedOrigins(state, [
       "PaymentStateQrCode",
       "PaymentStateManualEntry",
@@ -402,7 +402,7 @@ const summaryReducer: PaymentReducer = (
     };
   }
   if (
-    isActionOf(paymentTransactionSummaryFromBanner, action) &&
+    isActionOf(setPaymentStateToSummaryWithPaymentId, action) &&
     isInAllowedOrigins(state, [
       "PaymentStatePickPaymentMethod",
       "PaymentStateConfirmPaymentMethod",
@@ -440,7 +440,7 @@ const pickMethodReducer: PaymentReducer = (
   action: Action
 ) => {
   if (
-    isActionOf(paymentInitialPickPaymentMethod, action) &&
+    isActionOf(setPaymentStateFromSummaryToPickPaymentMethod, action) &&
     isInAllowedOrigins(state, [
       "PaymentStateSummary"
       // "PaymentStateSummaryWithPaymentId",
@@ -466,7 +466,7 @@ const pickMethodReducer: PaymentReducer = (
     };
   }
   if (
-    isActionOf(paymentPickPaymentMethod, action) &&
+    isActionOf(setPaymentStateToPickPaymentMethod, action) &&
     isInAllowedOrigins(state, [
       "PaymentStateSummaryWithPaymentId",
       "PaymentStateConfirmPaymentMethod"
@@ -499,7 +499,7 @@ const confirmMethodReducer: PaymentReducer = (
   action: Action
 ) => {
   if (
-    isActionOf(paymentInitialConfirmPaymentMethod, action) &&
+    isActionOf(setPaymentStateFromSummaryToConfirmPaymentMethod, action) &&
     isInAllowedOrigins(state, ["PaymentStateSummary"]) &&
     isPaymentStateWithVerificaResponse(state)
   ) {
@@ -516,7 +516,7 @@ const confirmMethodReducer: PaymentReducer = (
     };
   }
   if (
-    isActionOf(paymentConfirmPaymentMethod, action) &&
+    isActionOf(setPaymentStateToConfirmPaymentMethod, action) &&
     isInAllowedOrigins(state, [
       "PaymentStatePickPaymentMethod",
       "PaymentStateSummaryWithPaymentId",
@@ -547,7 +547,7 @@ const pickPspReducer: PaymentReducer = (
   action: Action
 ) => {
   if (
-    isActionOf(paymentInitialPickPsp, action) &&
+    isActionOf(setPaymentStateFromSummaryToPickPsp, action) &&
     isInAllowedOrigins(state, ["PaymentStateSummary"]) &&
     isPaymentStateWithVerificaResponse(state)
   ) {
@@ -564,7 +564,7 @@ const pickPspReducer: PaymentReducer = (
     };
   }
   if (
-    isActionOf(paymentPickPsp, action) &&
+    isActionOf(setPaymentStateToPickPsp, action) &&
     isInAllowedOrigins(state, [
       "PaymentStateSummaryWithPaymentId",
       "PaymentStateConfirmPaymentMethod",
@@ -594,7 +594,7 @@ const goBackReducer: PaymentReducer = (
   state: PaymentState = PAYMENT_INITIAL_STATE,
   action: Action
 ) => {
-  if (isActionOf(paymentGoBack, action)) {
+  if (isActionOf(goBackOnePaymentState, action)) {
     // if going back means going to the "initial" summary screen
     // (i.e. where the "attiva" is done and the payment id is fetched,
     // return to a state that also has the payment Id
@@ -641,7 +641,7 @@ const endPaymentReducer: PaymentReducer = (
   action: Action
 ) => {
   if (
-    isActionOf(paymentPinLogin, action) &&
+    isActionOf(setPaymentStateToPinLogin, action) &&
     isInAllowedOrigins(state, ["PaymentStateConfirmPaymentMethod"]) &&
     isPaymentStateWithSelectedPaymentMethod(state)
   ) {
@@ -657,7 +657,7 @@ const endPaymentReducer: PaymentReducer = (
     };
   }
   if (
-    isActionOf(paymentCompleted, action) &&
+    isActionOf(resetPaymentState, action) &&
     isInAllowedOrigins(state, ["PaymentStatePinLogin"])
   ) {
     return {

--- a/ts/store/reducers/wallet/wallets.ts
+++ b/ts/store/reducers/wallet/wallets.ts
@@ -39,6 +39,11 @@ export const getSelectedWalletId = (state: GlobalState) =>
   state.wallet.wallets.selectedWalletId;
 export const getFavoriteWalletId = (state: GlobalState) =>
   state.wallet.wallets.favoriteWalletId;
+export const getFavoriteWallet = (state: GlobalState) =>
+  state.wallet.wallets.favoriteWalletId.mapNullable(
+    walletId => state.wallet.wallets.list[walletId]
+  );
+
 export const getNewCreditCard = (state: GlobalState) =>
   state.wallet.wallets.newCreditCard;
 


### PR DESCRIPTION
Instead have screens forward data to the sagas, making sure we're always in a consistent state and making sure sagas always have the data they need (because it comes from the screen that triggered the saga, through an action).

Incidentally also adds state/activity diagrams for the wallet sagas.