### PR TITLE
[#161081455] Handle "card already exists" error

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -245,6 +245,7 @@ wallet:
       so that you don't have to re-add them from scratch for every transaction
     successful: The card was added successfully!
     failed: The card could not be added
+    failedCardAlreadyExists: The card you are adding already exists
   textMsg:
     title: Text confirmation code
     header: Confirmation code

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -252,6 +252,7 @@ wallet:
       ecc.) per non doverli inserire ad ogni transazione
     successful: Carta aggiunta con successo
     failed: Impossibile aggiungere la carta
+    failedCardAlreadyExists: La carta che stai inserendo è già presente
   textMsg:
     title: Codice di conferma
     header: Codice di Conferma SMS

--- a/ts/api/pagopa.ts
+++ b/ts/api/pagopa.ts
@@ -5,19 +5,24 @@
 import {
   ApiHeaderJson,
   AuthorizationBearerHeaderProducer,
-  basicErrorResponseDecoder,
   composeHeaderProducers,
   composeResponseDecoders,
   createFetchRequestForApi,
   IDeleteApiRequestType,
   IGetApiRequestType,
+  ioResponseDecoder,
   IPostApiRequestType,
   IPutApiRequestType,
   IResponseType,
   TypeofApiParams
 } from "italia-ts-commons/lib/requests";
 
-import { NullableWallet, PagopaToken, PspListResponse } from "../types/pagopa";
+import {
+  NullableWallet,
+  PagoPAErrorResponse,
+  PagopaToken,
+  PspListResponse
+} from "../types/pagopa";
 import { SessionResponse } from "../types/pagopa";
 import { TransactionListResponse } from "../types/pagopa";
 import { TransactionResponse } from "../types/pagopa";
@@ -162,7 +167,7 @@ const updateWalletPsp: (
 type AddWalletCreditCardUsingPOSTTWith422 = AddResponseType<
   AddWalletCreditCardUsingPOSTT,
   422,
-  Error
+  PagoPAErrorResponse
 >;
 
 const boardCreditCard: (
@@ -182,7 +187,7 @@ const boardCreditCard: (
   ),
   response_decoder: composeResponseDecoders(
     addWalletCreditCardUsingPOSTDecoder(WalletResponse),
-    basicErrorResponseDecoder<422>(422)
+    ioResponseDecoder<422, PagoPAErrorResponse>(422, PagoPAErrorResponse)
   )
 });
 

--- a/ts/api/pagopa.ts
+++ b/ts/api/pagopa.ts
@@ -5,7 +5,9 @@
 import {
   ApiHeaderJson,
   AuthorizationBearerHeaderProducer,
+  basicErrorResponseDecoder,
   composeHeaderProducers,
+  composeResponseDecoders,
   createFetchRequestForApi,
   IDeleteApiRequestType,
   IGetApiRequestType,
@@ -45,6 +47,7 @@ import {
   UpdateWalletUsingPUTT
 } from "../../definitions/pagopa/requestTypes";
 
+import { AddResponseType } from "../types/utils";
 import { defaultRetryingFetch, pagopaFetch } from "../utils/fetch";
 
 type MapTypeInApiResponse<T, S extends number, B> = T extends IResponseType<
@@ -154,10 +157,16 @@ const updateWalletPsp: (
   response_decoder: updateWalletUsingPUTDecoder(WalletResponse)
 });
 
+type AddWalletCreditCardUsingPOSTTWith422 = AddResponseType<
+  AddWalletCreditCardUsingPOSTT,
+  422,
+  Error
+>;
+
 const boardCreditCard: (
   pagoPaToken: PagopaToken
 ) => MapResponseType<
-  AddWalletCreditCardUsingPOSTT,
+  AddWalletCreditCardUsingPOSTTWith422,
   200,
   WalletResponse
 > = pagoPaToken => ({
@@ -169,7 +178,10 @@ const boardCreditCard: (
     AuthorizationBearerHeaderProducer(pagoPaToken),
     ApiHeaderJson
   ),
-  response_decoder: addWalletCreditCardUsingPOSTDecoder(WalletResponse)
+  response_decoder: composeResponseDecoders(
+    addWalletCreditCardUsingPOSTDecoder(WalletResponse),
+    basicErrorResponseDecoder<422>(422)
+  )
 });
 
 const postPayment: (

--- a/ts/api/pagopa.ts
+++ b/ts/api/pagopa.ts
@@ -157,6 +157,8 @@ const updateWalletPsp: (
   response_decoder: updateWalletUsingPUTDecoder(WalletResponse)
 });
 
+// Remove this patch once SIA has fixed the spec.
+// @see https://www.pivotaltracker.com/story/show/161113136
 type AddWalletCreditCardUsingPOSTTWith422 = AddResponseType<
   AddWalletCreditCardUsingPOSTT,
   422,

--- a/ts/sagas/wallet.ts
+++ b/ts/sagas/wallet.ts
@@ -180,7 +180,9 @@ function* addCreditCard(
     > = yield call(fetchWithTokenRefresh, boardCreditCard, pagoPaClient);
 
     const failedCardAlreadyExists =
-      typeof responseBoardCC !== "undefined" && responseBoardCC.status === 422;
+      typeof responseBoardCC !== "undefined" &&
+      responseBoardCC.status === 422 &&
+      responseBoardCC.value.message === "creditcard.already_exists";
 
     /**
      * Failed request. show an error (TODO) and return

--- a/ts/sagas/wallet.ts
+++ b/ts/sagas/wallet.ts
@@ -121,6 +121,7 @@ import {
 } from "./wallet/utils";
 
 import { PaymentActivationsPostResponse } from "../../definitions/backend/PaymentActivationsPostResponse";
+import { showToast } from "../utils/showToast";
 
 const navigateTo = (routeName: string, params?: object) => {
   return NavigationActions.navigate({ routeName, params });
@@ -178,19 +179,32 @@ function* addCreditCard(
       typeof boardCreditCard
     > = yield call(fetchWithTokenRefresh, boardCreditCard, pagoPaClient);
 
+    const failedCardAlreadyExists =
+      typeof responseBoardCC !== "undefined" && responseBoardCC.status === 422;
+
     /**
      * Failed request. show an error (TODO) and return
      * @https://www.pivotaltracker.com/story/show/160521051
      */
-    if (responseBoardCC === undefined || responseBoardCC.status !== 200) {
+    if (
+      failedCardAlreadyExists ||
+      typeof responseBoardCC === "undefined" ||
+      responseBoardCC.status !== 200
+    ) {
       yield put(creditCardDataCleanup());
       yield put(navigateTo(ROUTES.WALLET_HOME));
-      Toast.show({
-        text: I18n.t("wallet.newPaymentMethod.failed"),
-        type: "danger"
-      });
+
+      showToast(
+        I18n.t(
+          failedCardAlreadyExists
+            ? "wallet.newPaymentMethod.failedCardAlreadyExists"
+            : "wallet.newPaymentMethod.failed"
+        )
+      );
+
       return;
     }
+
     // 1st call was successful. Proceed with the 2nd one
     // (boarding pay)
     const { idWallet } = responseBoardCC.value.data;

--- a/ts/types/pagopa.ts
+++ b/ts/types/pagopa.ts
@@ -259,3 +259,10 @@ export type Pay = t.TypeOf<typeof Pay>;
 export const PayRequest = repP(PayRequestPagoPA, "data", Pay, "PayRequest");
 
 export type PayRequest = t.TypeOf<typeof PayRequest>;
+
+export const PagoPAErrorResponse = t.type({
+  code: t.string,
+  message: t.string
+});
+
+export type PagoPAErrorResponse = t.TypeOf<typeof PagoPAErrorResponse>;

--- a/ts/types/utils.ts
+++ b/ts/types/utils.ts
@@ -1,6 +1,13 @@
 // tslint:disable:readonly-array
 
 import * as t from "io-ts";
+import {
+  IDeleteApiRequestType,
+  IGetApiRequestType,
+  IPostApiRequestType,
+  IPutApiRequestType,
+  IResponseType
+} from "italia-ts-commons/lib/requests";
 import { Effect } from "redux-saga";
 
 export type SagaCallReturnType<
@@ -65,3 +72,17 @@ export const replaceProp1 = <
   name?: string
 ): t.Type<ReplaceProp1<A, P, A1>, O, I> =>
   t.refinement(type, o => typeB.is(o[p]), name) as any;
+
+export type AddResponseType<
+  T,
+  S extends number,
+  A
+> = T extends IGetApiRequestType<infer P1, infer H1, infer Q1, infer R1>
+  ? IGetApiRequestType<P1, H1, Q1, R1 | IResponseType<S, A>>
+  : T extends IPostApiRequestType<infer P2, infer H2, infer Q2, infer R2>
+    ? IPostApiRequestType<P2, H2, Q2, R2 | IResponseType<S, A>>
+    : T extends IPutApiRequestType<infer P3, infer H3, infer Q3, infer R3>
+      ? IPutApiRequestType<P3, H3, Q3, R3 | IResponseType<S, A>>
+      : T extends IDeleteApiRequestType<infer P4, infer H4, infer Q4, infer R4>
+        ? IDeleteApiRequestType<P4, H4, Q4, R4 | IResponseType<S, A>>
+        : never;

--- a/ts/utils/showToast.ts
+++ b/ts/utils/showToast.ts
@@ -1,0 +1,17 @@
+import { Toast } from "native-base";
+
+type Type = "danger" | "success" | "warning";
+
+export const showToast = (text: string, type: Type = "danger") =>
+  Toast.show({
+    text,
+    type,
+    duration: 5000,
+    buttonText: "✕",
+    buttonTextStyle: {
+      fontSize: 18
+    },
+    buttonStyle: {
+      backgroundColor: "transparent"
+    }
+  });


### PR DESCRIPTION
This PR patches the `AddWalletCreditCardUsingPOSTT` type in order to decode the `422` response status, meaning that the card already exists in the wallet.
There is also a new function which invoke `Toast.show()` with some default parameters (mainly duration and button style), should we refactor all the toasts using this helper function?

@matteodesanti The actual toast component we are using doesn't accept a component as a button, meaning that we can use the icon font, so I used the `✕` character.

![card-already-exists](https://user-images.githubusercontent.com/11299464/46728597-74f81e80-cc83-11e8-9379-0b65c7a205b3.gif)
