### PR TITLE
[#160720288] Add markdown demo custom tag

### DIFF
--- a/locales/en/markdown_reference.md
+++ b/locales/en/markdown_reference.md
@@ -1,3 +1,5 @@
+[demo]I am a custom demo tag at the beginning of the markdown[/demo]
+
 # Titolo h1: Lorem ipsum dolor sit amet, consectetur adipisici elit
 
 Testo semplice
@@ -17,6 +19,7 @@ Lorem ipsum dolor sit amet, consectetur adipisici elit, sed eiusmod tempor incid
 Nec dubitamus multa iter quae et nos invenerat. Cum sociis natoque penatibus et magnis dis parturient. Donec sed odio operae, eu vulputate felis rhoncus. Tityre, tu patulae recubans sub tegmine fagi dolor. At nos hinc posthac, sitientis piros Afros. Non equidem invideo, miror magis posuere velit aliquet.  
 Hi omnes lingua, institutis, legibus inter se differunt. Quae vero auctorem tractata ab fiducia dicuntur. Plura mihi bona sunt, inclinet, amari petere vellent. Sed haec quis possit intrepidus aestimare tellus. Curabitur blandit tempus ardua ridiculus sed magna.
 
+[demo]I am a custom demo tag in the middle of the markdown[/demo]
 
 Lorem ipsum dolor sit amet, consectetur adipisici elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Fabio vel iudice vincam, sunt in culpa qui officia.
 

--- a/locales/it/markdown_reference.md
+++ b/locales/it/markdown_reference.md
@@ -1,3 +1,5 @@
+[demo]I am a custom demo tag at the beginning of the markdown[/demo]
+
 # Titolo h1: Lorem ipsum dolor sit amet, consectetur adipisici elit
 
 Testo semplice
@@ -17,6 +19,7 @@ Lorem ipsum dolor sit amet, consectetur adipisici elit, sed eiusmod tempor incid
 Nec dubitamus multa iter quae et nos invenerat. Cum sociis natoque penatibus et magnis dis parturient. Donec sed odio operae, eu vulputate felis rhoncus. Tityre, tu patulae recubans sub tegmine fagi dolor. At nos hinc posthac, sitientis piros Afros. Non equidem invideo, miror magis posuere velit aliquet.  
 Hi omnes lingua, institutis, legibus inter se differunt. Quae vero auctorem tractata ab fiducia dicuntur. Plura mihi bona sunt, inclinet, amari petere vellent. Sed haec quis possit intrepidus aestimare tellus. Curabitur blandit tempus ardua ridiculus sed magna.
 
+[demo]I am a custom demo tag in the middle of the markdown[/demo]
 
 Lorem ipsum dolor sit amet, consectetur adipisici elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Fabio vel iudice vincam, sunt in culpa qui officia.
 

--- a/ts/@types/simple-markdown.d.ts
+++ b/ts/@types/simple-markdown.d.ts
@@ -1,5 +1,9 @@
 declare module "simple-markdown" {
-  export const defaultRules = {};
+  export const defaultRules: DefaultRules;
+
+  export type DefaultRules = Readonly<{
+    [key: string]: any
+  }>;
 
   export type SingleASTNode = Readonly<{
     type: string,
@@ -10,6 +14,12 @@ declare module "simple-markdown" {
 
   export type State = {
     [key: string]: any
+  };
+
+  type Capture = {
+    '0': string,
+    index?: number,
+    [key: number]: string,
   };
 
   export type Parser = (

--- a/ts/components/ui/Markdown/MarkdownDemo.tsx
+++ b/ts/components/ui/Markdown/MarkdownDemo.tsx
@@ -1,0 +1,43 @@
+import { View } from "native-base";
+import { connectStyle } from "native-base-shoutem-theme";
+import mapPropsToStyleNames from "native-base/src/utils/mapPropsToStyleNames";
+import * as React from "react";
+import { StyleSheet } from "react-native";
+import { Col, Grid } from "react-native-easy-grid";
+
+import { ComponentProps } from "../../../types/react";
+import IconFont from "../../ui/IconFont";
+
+type Props = ComponentProps<View>;
+
+const styles = StyleSheet.create({
+  textColumn: {
+    paddingRight: 10
+  },
+  iconColumn: {
+    flexDirection: "row",
+    alignItems: "center"
+  }
+});
+
+class MarkdownDemo extends React.PureComponent<Props, never> {
+  public render() {
+    return (
+      <View {...this.props}>
+        <Grid>
+          <Col size={11} style={styles.textColumn}>
+            {this.props.children}
+          </Col>
+          <Col size={1} style={styles.iconColumn}>
+            <IconFont name="io-notice" />
+          </Col>
+        </Grid>
+      </View>
+    );
+  }
+}
+export default connectStyle(
+  "UIComponent.MarkdownDemo",
+  {},
+  mapPropsToStyleNames
+)(MarkdownDemo);

--- a/ts/components/ui/Markdown/rules/demo.ts
+++ b/ts/components/ui/Markdown/rules/demo.ts
@@ -1,0 +1,45 @@
+import * as React from "react";
+import {
+  Capture,
+  defaultRules,
+  Parser,
+  ReactOutput,
+  SingleASTNode,
+  State
+} from "simple-markdown";
+
+import MarkdownDemo from "../MarkdownDemo";
+
+const rule = {
+  order: defaultRules.blockQuote.order,
+
+  // First we check whether a string matches
+  match: (source: string) => {
+    return /^\[demo\]([\s\S]+?)\[\/demo\]+\n{2,}/.exec(source);
+  },
+
+  // Then parse this string into a syntax node
+  parse: (capture: Capture, parse: Parser, state: State) => {
+    return {
+      content: parse(`${capture[1]}\n\n`, state)
+    };
+  },
+
+  // Finally transform this syntax node into a
+  // React element
+  react_native: (
+    node: SingleASTNode,
+    output: ReactOutput,
+    state: State
+  ): React.ReactNode => {
+    return React.createElement(
+      MarkdownDemo,
+      {
+        key: state.key
+      },
+      output(node.content, state)
+    );
+  }
+};
+
+export default rule;

--- a/ts/components/ui/Markdown/rules/index.ts
+++ b/ts/components/ui/Markdown/rules/index.ts
@@ -1,5 +1,6 @@
 import blockQuoteRule from "./blockQuote";
 import brRule from "./br";
+import demoRule from "./demo";
 import emRule from "./em";
 import defaultRule from "./empty";
 import headingRule from "./heading";
@@ -25,6 +26,7 @@ const rules = {
   codeBlock: defaultRule,
   def: defaultRule,
   del: defaultRule,
+  demo: demoRule,
   em: emRule,
   escape: defaultRule,
   fence: defaultRule,

--- a/ts/theme/components/markdown/MarkdownDemo.ts
+++ b/ts/theme/components/markdown/MarkdownDemo.ts
@@ -1,0 +1,15 @@
+import { Theme } from "../../types";
+
+export default (): Theme => {
+  return {
+    "NativeBase.ViewNB": {
+      "UIComponent.MarkdownParagraph": {
+        padding: 0
+      },
+
+      backgroundColor: "#c1f4f2",
+      marginBottom: 50,
+      padding: 20
+    }
+  };
+};

--- a/ts/theme/index.ts
+++ b/ts/theme/index.ts
@@ -34,6 +34,7 @@ import variables from "./variables";
 
 import markdownBlockQuoteTheme from "./components/markdown/MarkdownBlockQuote";
 import markdownBrTheme from "./components/markdown/MarkdownBr";
+import markdownDemoTheme from "./components/markdown/MarkdownDemo";
 import markdownHeadingTheme from "./components/markdown/MarkdownHeading";
 import markdownListTheme from "./components/markdown/MarkdownList";
 import markdownParagraphTheme from "./components/markdown/MarkdownParagraph";
@@ -123,6 +124,9 @@ const theme = (): Theme => {
     },
     "UIComponent.MarkdownBr": {
       ...markdownBrTheme()
+    },
+    "UIComponent.MarkdownDemo": {
+      ...markdownDemoTheme()
     },
     "UIComponent.MarkdownHeading": {
       ...markdownHeadingTheme()


### PR DESCRIPTION
Use

`[demo]My paragraph[/demo]`

to add a style like in the figure.

![demo](https://user-images.githubusercontent.com/30595520/46740794-ef389b00-cca3-11e8-811b-fade9e6dfeb6.png)

@matteodesanti The font icon need to be re-exported, the one attached in the pivotal task seem not working.