### PR TITLE
[#160350840] Fix and improve the fetching of PagoPA token and its refreshing.

### DIFF
--- a/ts/sagas/wallet.ts
+++ b/ts/sagas/wallet.ts
@@ -1033,7 +1033,7 @@ export function* watchWalletSaga(
   // Note that fetchAndStorePagoPaToken has a side effect of emitting an action
   // that stores the token in the Redux store.
   // TODO: document this flow
-  yield call(fetchAndStorePagoPaToken, pagoPaClient);
+  yield fork(fetchAndStorePagoPaToken, pagoPaClient);
 
   // Start listening for actions that start the payment flow
   yield takeLatest(

--- a/ts/sagas/wallet/utils.ts
+++ b/ts/sagas/wallet/utils.ts
@@ -1,13 +1,21 @@
-import { Option, some } from "fp-ts/lib/Option";
+import { Option } from "fp-ts/lib/Option";
 import { IResponseType } from "italia-ts-commons/lib/requests";
-import { call, Effect, put, select } from "redux-saga/effects";
+import { call, Effect, put, select, take } from "redux-saga/effects";
+import { getType } from "typesafe-actions";
 
 import { PagoPaClient } from "../../api/pagopa";
 import { PagopaToken } from "../../types/pagopa";
 
-import { storePagoPaToken } from "../../store/actions/wallet/pagopa";
+import {
+  pagoPaTokenFailure,
+  pagoPaTokenRequest,
+  pagoPaTokenSuccess
+} from "../../store/actions/wallet/pagopa";
 import { GlobalState } from "../../store/reducers/types";
-import { getPagoPaToken } from "../../store/reducers/wallet/pagopa";
+import {
+  getPagoPaToken,
+  isRequestingPagoPaTokenSelector
+} from "../../store/reducers/wallet/pagopa";
 
 import { SagaCallReturnType } from "../../types/utils";
 
@@ -15,17 +23,20 @@ import { SagaCallReturnType } from "../../types/utils";
 const MAX_TOKEN_REFRESHES = 2;
 
 export function* fetchAndStorePagoPaToken(pagoPaClient: PagoPaClient) {
+  yield put(pagoPaTokenRequest());
+
   const refreshTokenResponse: SagaCallReturnType<
     typeof pagoPaClient.getSession
   > = yield call(pagoPaClient.getSession, pagoPaClient.walletToken);
+
   if (
     refreshTokenResponse !== undefined &&
     refreshTokenResponse.status === 200
   ) {
-    // token fetched successfully, store it
-    yield put(
-      storePagoPaToken(some(refreshTokenResponse.value.data.sessionToken))
-    );
+    // Token fetched successfully, store it.
+    yield put(pagoPaTokenSuccess(refreshTokenResponse.value.data.sessionToken));
+  } else {
+    yield put(pagoPaTokenFailure());
   }
 }
 
@@ -46,36 +57,45 @@ export function* fetchWithTokenRefresh<T>(
   retries: number = MAX_TOKEN_REFRESHES
 ): Iterator<T | undefined | Effect> {
   if (retries === 0) {
-    return undefined;
+    return;
   }
+
   const pagoPaToken: Option<PagopaToken> = yield select<GlobalState>(
     getPagoPaToken
   );
-  const response: SagaCallReturnType<typeof request> = yield call(
-    request,
-    pagoPaToken.getOrElse("" as PagopaToken) // empty token -> pagoPA returns a 401 and the app fetches a new one
-    // FIXME: ^^^^^^^^^ why do the request anyway if we already know that it will fail????
-  );
-  if (response !== undefined) {
+
+  if (pagoPaToken.isSome()) {
+    const response: SagaCallReturnType<typeof request> = yield call(
+      request,
+      pagoPaToken.value
+    );
+
+    if (response === undefined) {
+      return;
+    }
+
     // BEWARE: since there is not an easy way to restrict T to an arbitrary union
     // of IResponseType(s), we kind of take a leap of faith here and assume that T
     // is always a union of IResponseType(s) together with undefined.
     if ((response as any).status !== 401) {
-      // return code is not 401, the token
-      // has been "accepted" (the caller will
-      // then handle other error codes)
+      // Return code is not 401, the token has been "accepted"
+      // (the caller will then handle other error codes).
       return response;
-    } else {
-      yield call(fetchAndStorePagoPaToken, pagoPaClient);
-
-      // and retry fetching the result
-      return yield call(
-        fetchWithTokenRefresh,
-        request,
-        pagoPaClient,
-        retries - 1
-      );
     }
   }
-  return undefined;
+
+  const isRequestingPagoPaToken: boolean = yield select(
+    isRequestingPagoPaTokenSelector
+  );
+
+  if (isRequestingPagoPaToken) {
+    // Wait to receive response.
+    yield take(getType(pagoPaTokenSuccess));
+  } else {
+    // Request new token
+    yield call(fetchAndStorePagoPaToken, pagoPaClient);
+  }
+
+  // Retry fetching the result.
+  return yield call(fetchWithTokenRefresh, request, pagoPaClient, retries - 1);
 }

--- a/ts/store/actions/wallet/pagopa.ts
+++ b/ts/store/actions/wallet/pagopa.ts
@@ -1,10 +1,21 @@
-import { Option } from "fp-ts/lib/Option";
 import { ActionType, createStandardAction } from "typesafe-actions";
 
 import { PagopaToken } from "../../../types/pagopa";
 
-export const storePagoPaToken = createStandardAction("PAGOPA_STORE_TOKEN")<
-  Option<PagopaToken>
+export const pagoPaTokenRequest = createStandardAction(
+  "PAGOPA_TOKEN_REQUEST"
+)();
+
+export const pagoPaTokenFailure = createStandardAction(
+  "PAGOPA_TOKEN_FAILURE"
+)();
+
+export const pagoPaTokenSuccess = createStandardAction("PAGOPA_TOKEN_SUCCESS")<
+  PagopaToken
 >();
 
-export type PagoPaActions = ActionType<typeof storePagoPaToken>;
+export type PagoPaActions = ActionType<
+  | typeof pagoPaTokenRequest
+  | typeof pagoPaTokenFailure
+  | typeof pagoPaTokenSuccess
+>;

--- a/ts/store/reducers/wallet/pagopa.ts
+++ b/ts/store/reducers/wallet/pagopa.ts
@@ -1,30 +1,87 @@
-import { none, Option } from "fp-ts/lib/Option";
-import { isActionOf } from "typesafe-actions";
+import { none, some } from "fp-ts/lib/Option";
+import { getType } from "typesafe-actions";
 
 import { PagopaToken } from "../../../types/pagopa";
 
 import { Action } from "../../actions/types";
-import { storePagoPaToken } from "../../actions/wallet/pagopa";
+import {
+  pagoPaTokenFailure,
+  pagoPaTokenRequest,
+  pagoPaTokenSuccess
+} from "../../actions/wallet/pagopa";
 import { GlobalState } from "../types";
 
-export type PagoPaState = Readonly<{
-  token: Option<PagopaToken>;
-}>;
+interface NoToken {
+  kind: "NotRequested";
+}
 
-const PAGOPA_INITIAL_STATE = {
-  token: none
+export type PagoPaState =
+  | NoToken
+  | { kind: "Requesting" }
+  | { kind: "Success"; token: PagopaToken }
+  | { kind: "Failure" };
+
+const PAGOPA_INITIAL_STATE: NoToken = {
+  kind: "NotRequested"
 };
 
-export const getPagoPaToken = (state: GlobalState) => state.wallet.pagoPa.token;
+function matchPagoPaState<O>(
+  state: PagoPaState,
+  whenNotRequested: () => O,
+  whenRequesting: () => O,
+  whenSuccess: (token: PagopaToken) => O,
+  whenFailure: () => O
+) {
+  switch (state.kind) {
+    case "NotRequested":
+      return whenNotRequested();
 
-const reducer = (state: PagoPaState = PAGOPA_INITIAL_STATE, action: Action) => {
-  if (isActionOf(storePagoPaToken, action)) {
-    return {
-      ...state,
-      token: action.payload
-    };
+    case "Requesting":
+      return whenRequesting();
+
+    case "Success":
+      return whenSuccess(state.token);
+
+    case "Failure":
+      return whenFailure();
   }
-  return state;
+}
+
+export const getPagoPaToken = (state: GlobalState) =>
+  matchPagoPaState(
+    state.wallet.pagoPa,
+    () => none,
+    () => none,
+    token => some(token),
+    () => none
+  );
+
+export const isRequestingPagoPaTokenSelector = (state: GlobalState) =>
+  matchPagoPaState(
+    state.wallet.pagoPa,
+    () => false,
+    () => true,
+    () => false,
+    () => false
+  );
+
+const reducer = (
+  state: PagoPaState = PAGOPA_INITIAL_STATE,
+  action: Action
+): PagoPaState => {
+  switch (action.type) {
+    case getType(pagoPaTokenRequest):
+      return { kind: "Requesting" };
+
+    case getType(pagoPaTokenSuccess):
+      return { kind: "Success", token: action.payload };
+
+    case getType(pagoPaTokenFailure):
+      return { kind: "Failure" };
+
+    default:
+      return state;
+  }
 };
 
 export default reducer;


### PR DESCRIPTION
This PR improve the refreshing of the PagoPA token. When requesting a new token, the *requesting* state is saved inside the redux store. If other token requests happen and a request is already running, they wait for them and the new token.