### PR TITLE
Refactor data flow for wallet and transaction details screens to avoid the redux store  

### DIFF
--- a/ts/components/wallet/PaymentBannerComponent.tsx
+++ b/ts/components/wallet/PaymentBannerComponent.tsx
@@ -9,7 +9,6 @@ import { Text, View } from "native-base";
 import * as React from "react";
 import { TouchableOpacity } from "react-native";
 import { Col, Grid, Row } from "react-native-easy-grid";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
 import { EnteBeneficiario } from "../../../definitions/backend/EnteBeneficiario";
 import I18n from "../../i18n";
@@ -41,11 +40,7 @@ type ReduxMappedDispatchProps = Readonly<{
   showSummary: () => void;
 }>;
 
-type OwnProps = Readonly<{
-  navigation: NavigationScreenProp<NavigationState>;
-}>;
-
-type Props = OwnProps & ReduxMappedStateProps & ReduxMappedDispatchProps;
+type Props = ReduxMappedStateProps & ReduxMappedDispatchProps;
 
 class PaymentBannerComponent extends React.Component<Props> {
   public shouldComponentUpdate(nextProps: Props) {

--- a/ts/components/wallet/TransactionsList.tsx
+++ b/ts/components/wallet/TransactionsList.tsx
@@ -16,12 +16,10 @@ import {
   View
 } from "native-base";
 import * as React from "react";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
 
 import IconFont from "../../components/ui/IconFont";
 import I18n from "../../i18n";
-import ROUTES from "../../navigation/routes";
 import { Dispatch } from "../../store/actions/types";
 import { selectTransactionForDetails } from "../../store/actions/wallet/transactions";
 import { selectWalletForDetails } from "../../store/actions/wallet/wallets";
@@ -61,8 +59,8 @@ export enum TransactionsDisplayed {
 type OwnProps = Readonly<{
   title: string;
   totalAmount: string;
-  navigation: NavigationScreenProp<NavigationState>;
   display: TransactionsDisplayed;
+  navigateToTransactionDetails: () => void;
 }>;
 
 type Props = OwnProps & ReduxMappedStateProps & ReduxMappedDispatchProps;
@@ -98,7 +96,7 @@ class TransactionsList extends React.Component<Props> {
         onPress={() => {
           this.props.selectTransaction(item);
           this.props.selectWallet(item.idWallet);
-          this.props.navigation.navigate(ROUTES.WALLET_TRANSACTION_DETAILS);
+          this.props.navigateToTransactionDetails();
         }}
       >
         <Body>

--- a/ts/components/wallet/TransactionsList.tsx
+++ b/ts/components/wallet/TransactionsList.tsx
@@ -20,14 +20,11 @@ import { connect } from "react-redux";
 
 import IconFont from "../../components/ui/IconFont";
 import I18n from "../../i18n";
-import { Dispatch } from "../../store/actions/types";
-import { selectTransactionForDetails } from "../../store/actions/wallet/transactions";
-import { selectWalletForDetails } from "../../store/actions/wallet/wallets";
 import { createLoadingSelector } from "../../store/reducers/loading";
 import { GlobalState } from "../../store/reducers/types";
 import {
-  latestTransactionsSelector,
-  transactionsByWalletSelector
+  getTransactions,
+  latestTransactionsSelector
 } from "../../store/reducers/wallet/transactions";
 import { Transaction } from "../../types/pagopa";
 import { buildAmount, centsToAmount } from "../../utils/stringBuilder";
@@ -43,11 +40,6 @@ type ReduxMappedStateProps =
       isLoading: true;
     }>;
 
-type ReduxMappedDispatchProps = Readonly<{
-  selectTransaction: (i: Transaction) => void;
-  selectWallet: (item: number) => void;
-}>;
-
 /**
  * The type of transactions that are to be shown
  */
@@ -60,10 +52,10 @@ type OwnProps = Readonly<{
   title: string;
   totalAmount: string;
   display: TransactionsDisplayed;
-  navigateToTransactionDetails: () => void;
+  navigateToTransactionDetails: (transaction: Transaction) => void;
 }>;
 
-type Props = OwnProps & ReduxMappedStateProps & ReduxMappedDispatchProps;
+type Props = OwnProps & ReduxMappedStateProps;
 /**
  * Transactions List component
  */
@@ -93,11 +85,7 @@ class TransactionsList extends React.Component<Props> {
     return (
       <ListItem
         style={WalletStyles.listItem}
-        onPress={() => {
-          this.props.selectTransaction(item);
-          this.props.selectWallet(item.idWallet);
-          this.props.navigateToTransactionDetails();
-        }}
+        onPress={() => this.props.navigateToTransactionDetails(item)}
       >
         <Body>
           <Grid>
@@ -188,7 +176,7 @@ const mapStateToProps = (
     }
     case TransactionsDisplayed.BY_WALLET: {
       return {
-        transactions: transactionsByWalletSelector(state),
+        transactions: getTransactions(state),
         isLoading
       };
     }
@@ -196,12 +184,4 @@ const mapStateToProps = (
   return { transactions: [], isLoading };
 };
 
-const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedDispatchProps => ({
-  selectTransaction: item => dispatch(selectTransactionForDetails(item)),
-  selectWallet: (item: number) => dispatch(selectWalletForDetails(item))
-});
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(TransactionsList);
+export default connect(mapStateToProps)(TransactionsList);

--- a/ts/components/wallet/WalletLayout.tsx
+++ b/ts/components/wallet/WalletLayout.tsx
@@ -19,11 +19,9 @@ import {
 } from "native-base";
 import * as React from "react";
 import { ScrollView, StyleSheet, TouchableOpacity } from "react-native";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
 
 import I18n from "../../i18n";
-import ROUTES from "../../navigation/routes";
 import { Dispatch } from "../../store/actions/types";
 import {
   setPaymentStateToQrCode,
@@ -36,7 +34,7 @@ import { InstabugButtons } from "../InstabugButtons";
 import { WalletStyles } from "../styles/wallet";
 import AppHeader from "../ui/AppHeader";
 import IconFont from "../ui/IconFont";
-import CardComponent from "./card";
+import CardComponent from "./card/CardComponent";
 import { LogoPosition } from "./card/Logo";
 
 const styles = StyleSheet.create({
@@ -104,11 +102,13 @@ type ReduxMappedProps = Readonly<{
 
 type OwnProps = Readonly<{
   title: string;
-  navigation: NavigationScreenProp<NavigationState>;
   headerContents?: React.ReactNode;
   cardType?: CardType;
   showPayButton?: boolean;
   allowGoBack?: boolean;
+  navigateToWalletList: () => void;
+  navigateToScanQrCode: () => void;
+  navigateToCardTransactions: () => void;
 }>;
 
 type Props = OwnProps & ReduxMappedProps;
@@ -134,40 +134,36 @@ class WalletLayout extends React.Component<Props> {
       case CardEnum.FAN: {
         const { cards } = this.props.cardType;
         return (
-          <TouchableOpacity
-            onPress={(): boolean =>
-              this.props.navigation.navigate(ROUTES.WALLET_LIST)
-            }
-          >
+          <TouchableOpacity onPress={this.props.navigateToWalletList}>
             {cards.length === 1 ? (
               <View style={WalletStyles.container}>
                 <CardComponent
-                  navigation={this.props.navigation}
                   item={cards[0]}
                   logoPosition={LogoPosition.TOP}
                   flatBottom={true}
                   headerOnly={true}
                   rotated={true}
+                  navigateToDetails={this.props.navigateToCardTransactions}
                 />
               </View>
             ) : (
               <View style={styles.shiftDown}>
                 <View style={styles.firstCard}>
                   <CardComponent
-                    navigation={this.props.navigation}
                     item={cards[0]}
                     logoPosition={LogoPosition.TOP}
                     flatBottom={true}
                     headerOnly={true}
+                    navigateToDetails={this.props.navigateToCardTransactions}
                   />
                 </View>
                 <View style={styles.secondCard}>
                   <CardComponent
-                    navigation={this.props.navigation}
                     item={cards[1]}
                     logoPosition={LogoPosition.TOP}
                     flatBottom={true}
                     headerOnly={true}
+                    navigateToDetails={this.props.navigateToCardTransactions}
                   />
                 </View>
               </View>
@@ -179,12 +175,12 @@ class WalletLayout extends React.Component<Props> {
         return (
           <View style={WalletStyles.container}>
             <CardComponent
-              navigation={this.props.navigation}
               item={this.props.cardType.card}
               favorite={false}
               menu={true}
               lastUsage={false}
               flatBottom={true}
+              navigateToDetails={this.props.navigateToCardTransactions}
             />
           </View>
         );
@@ -193,12 +189,12 @@ class WalletLayout extends React.Component<Props> {
         return (
           <View style={WalletStyles.container}>
             <CardComponent
-              navigation={this.props.navigation}
               item={this.props.cardType.card}
               logoPosition={LogoPosition.TOP}
               flatBottom={true}
               headerOnly={true}
               rotated={true}
+              navigateToDetails={this.props.navigateToCardTransactions}
             />
           </View>
         );
@@ -243,7 +239,7 @@ class WalletLayout extends React.Component<Props> {
               block={true}
               onPress={() => {
                 this.props.setPaymentStateToQrCode();
-                this.props.navigation.navigate(ROUTES.PAYMENT_SCAN_QR_CODE);
+                this.props.navigateToScanQrCode();
                 this.props.startPaymentSaga();
               }}
             >

--- a/ts/components/wallet/WalletLayout.tsx
+++ b/ts/components/wallet/WalletLayout.tsx
@@ -108,7 +108,7 @@ type OwnProps = Readonly<{
   allowGoBack?: boolean;
   navigateToWalletList: () => void;
   navigateToScanQrCode: () => void;
-  navigateToCardTransactions: () => void;
+  navigateToWalletTransactions: (wallet: Wallet) => void;
 }>;
 
 type Props = OwnProps & ReduxMappedProps;
@@ -138,13 +138,13 @@ class WalletLayout extends React.Component<Props> {
             {cards.length === 1 ? (
               <View style={WalletStyles.container}>
                 <CardComponent
-                  item={cards[0]}
+                  wallet={cards[0]}
                   logoPosition={LogoPosition.TOP}
                   flatBottom={true}
                   headerOnly={true}
                   rotated={true}
-                  navigateToCardTransactions={
-                    this.props.navigateToCardTransactions
+                  navigateToWalletTransactions={
+                    this.props.navigateToWalletTransactions
                   }
                 />
               </View>
@@ -152,23 +152,23 @@ class WalletLayout extends React.Component<Props> {
               <View style={styles.shiftDown}>
                 <View style={styles.firstCard}>
                   <CardComponent
-                    item={cards[0]}
+                    wallet={cards[0]}
                     logoPosition={LogoPosition.TOP}
                     flatBottom={true}
                     headerOnly={true}
-                    navigateToCardTransactions={
-                      this.props.navigateToCardTransactions
+                    navigateToWalletTransactions={
+                      this.props.navigateToWalletTransactions
                     }
                   />
                 </View>
                 <View style={styles.secondCard}>
                   <CardComponent
-                    item={cards[1]}
+                    wallet={cards[1]}
                     logoPosition={LogoPosition.TOP}
                     flatBottom={true}
                     headerOnly={true}
-                    navigateToCardTransactions={
-                      this.props.navigateToCardTransactions
+                    navigateToWalletTransactions={
+                      this.props.navigateToWalletTransactions
                     }
                   />
                 </View>
@@ -181,12 +181,14 @@ class WalletLayout extends React.Component<Props> {
         return (
           <View style={WalletStyles.container}>
             <CardComponent
-              item={this.props.cardType.card}
+              wallet={this.props.cardType.card}
               favorite={false}
               menu={true}
               lastUsage={false}
               flatBottom={true}
-              navigateToCardTransactions={this.props.navigateToCardTransactions}
+              navigateToWalletTransactions={
+                this.props.navigateToWalletTransactions
+              }
             />
           </View>
         );
@@ -195,12 +197,14 @@ class WalletLayout extends React.Component<Props> {
         return (
           <View style={WalletStyles.container}>
             <CardComponent
-              item={this.props.cardType.card}
+              wallet={this.props.cardType.card}
               logoPosition={LogoPosition.TOP}
               flatBottom={true}
               headerOnly={true}
               rotated={true}
-              navigateToCardTransactions={this.props.navigateToCardTransactions}
+              navigateToWalletTransactions={
+                this.props.navigateToWalletTransactions
+              }
             />
           </View>
         );

--- a/ts/components/wallet/WalletLayout.tsx
+++ b/ts/components/wallet/WalletLayout.tsx
@@ -143,7 +143,9 @@ class WalletLayout extends React.Component<Props> {
                   flatBottom={true}
                   headerOnly={true}
                   rotated={true}
-                  navigateToDetails={this.props.navigateToCardTransactions}
+                  navigateToCardTransactions={
+                    this.props.navigateToCardTransactions
+                  }
                 />
               </View>
             ) : (
@@ -154,7 +156,9 @@ class WalletLayout extends React.Component<Props> {
                     logoPosition={LogoPosition.TOP}
                     flatBottom={true}
                     headerOnly={true}
-                    navigateToDetails={this.props.navigateToCardTransactions}
+                    navigateToCardTransactions={
+                      this.props.navigateToCardTransactions
+                    }
                   />
                 </View>
                 <View style={styles.secondCard}>
@@ -163,7 +167,9 @@ class WalletLayout extends React.Component<Props> {
                     logoPosition={LogoPosition.TOP}
                     flatBottom={true}
                     headerOnly={true}
-                    navigateToDetails={this.props.navigateToCardTransactions}
+                    navigateToCardTransactions={
+                      this.props.navigateToCardTransactions
+                    }
                   />
                 </View>
               </View>
@@ -180,7 +186,7 @@ class WalletLayout extends React.Component<Props> {
               menu={true}
               lastUsage={false}
               flatBottom={true}
-              navigateToDetails={this.props.navigateToCardTransactions}
+              navigateToCardTransactions={this.props.navigateToCardTransactions}
             />
           </View>
         );
@@ -194,7 +200,7 @@ class WalletLayout extends React.Component<Props> {
               flatBottom={true}
               headerOnly={true}
               rotated={true}
-              navigateToDetails={this.props.navigateToCardTransactions}
+              navigateToCardTransactions={this.props.navigateToCardTransactions}
             />
           </View>
         );

--- a/ts/components/wallet/card/CardBody.tsx
+++ b/ts/components/wallet/card/CardBody.tsx
@@ -7,13 +7,21 @@ import { Right, Text } from "native-base";
 import * as React from "react";
 import { StyleSheet } from "react-native";
 import { Col, Row } from "react-native-easy-grid";
-import { CardProps } from ".";
+
 import I18n from "../../../i18n";
+
 import variables from "../../../theme/variables";
+
+import { Wallet } from "../../../types/pagopa";
+
 import { buildExpirationDate } from "../../../utils/stringBuilder";
+
 import IconFont from "../../ui/IconFont";
+
 import FooterRow from "./FooterRow";
+
 import Logo, { LogoPosition, shouldRenderLogo } from "./Logo";
+
 import { CreditCardStyles } from "./style";
 
 const styles = StyleSheet.create({
@@ -25,7 +33,16 @@ const styles = StyleSheet.create({
   }
 });
 
-export default class CardBody extends React.Component<CardProps> {
+type Props = Readonly<{
+  item: Wallet;
+  logoPosition?: LogoPosition;
+  mainAction?: (wallet: Wallet) => void;
+  lastUsage?: boolean;
+  whiteLine?: boolean;
+  navigateToDetails: () => void;
+}>;
+
+export default class CardBody extends React.Component<Props> {
   /**
    * Display the right-end part of the
    * card body. This will be the card
@@ -78,7 +95,7 @@ export default class CardBody extends React.Component<CardProps> {
   }
 
   public render() {
-    const { item, navigation } = this.props;
+    const { item } = this.props;
     const expirationDate = buildExpirationDate(item);
     // returns a list of rows, namely:
     // - the "validity" row displaying when the card expires
@@ -109,10 +126,10 @@ export default class CardBody extends React.Component<CardProps> {
       this.whiteLine(),
       <FooterRow
         {...{
-          navigation,
           item,
           showMsg: this.props.lastUsage,
-          key: "footerRow"
+          key: "footerRow",
+          navigateToDetails: this.props.navigateToDetails
         }}
       />
     ];

--- a/ts/components/wallet/card/CardBody.tsx
+++ b/ts/components/wallet/card/CardBody.tsx
@@ -34,12 +34,12 @@ const styles = StyleSheet.create({
 });
 
 type Props = Readonly<{
-  item: Wallet;
+  wallet: Wallet;
   logoPosition?: LogoPosition;
   mainAction?: (wallet: Wallet) => void;
   lastUsage?: boolean;
   whiteLine?: boolean;
-  navigateToCardTransactions: () => void;
+  navigateToWalletTransactions: (item: Wallet) => void;
 }>;
 
 export default class CardBody extends React.Component<Props> {
@@ -64,7 +64,7 @@ export default class CardBody extends React.Component<Props> {
         <Row
           style={CreditCardStyles.rowStyle}
           onPress={() =>
-            mainAction !== undefined ? mainAction(this.props.item) : undefined
+            mainAction !== undefined ? mainAction(this.props.wallet) : undefined
           }
         >
           <Right>
@@ -78,7 +78,7 @@ export default class CardBody extends React.Component<Props> {
       );
     } else {
       return shouldRenderLogo(LogoPosition.CENTER, this.props.logoPosition) ? (
-        <Logo item={this.props.item} />
+        <Logo item={this.props.wallet} />
       ) : null;
     }
   }
@@ -95,8 +95,8 @@ export default class CardBody extends React.Component<Props> {
   }
 
   public render() {
-    const { item } = this.props;
-    const expirationDate = buildExpirationDate(item);
+    const { wallet } = this.props;
+    const expirationDate = buildExpirationDate(wallet);
     // returns a list of rows, namely:
     // - the "validity" row displaying when the card expires
     // - the "owner" row, displaying the owner name on the left-end
@@ -118,19 +118,17 @@ export default class CardBody extends React.Component<Props> {
       <Row key="owner" size={6} style={CreditCardStyles.rowStyle}>
         <Col size={7}>
           <Text style={CreditCardStyles.textStyle}>
-            {item.creditCard.holder.toUpperCase()}
+            {wallet.creditCard.holder.toUpperCase()}
           </Text>
         </Col>
         <Col size={2}>{this.rightPart()}</Col>
       </Row>,
       this.whiteLine(),
       <FooterRow
-        {...{
-          item,
-          showMsg: this.props.lastUsage,
-          key: "footerRow",
-          navigateToCardTransactions: this.props.navigateToCardTransactions
-        }}
+        wallet={wallet}
+        showMsg={this.props.lastUsage}
+        key={"footerRow"}
+        navigateToWalletTransactions={this.props.navigateToWalletTransactions}
       />
     ];
   }

--- a/ts/components/wallet/card/CardBody.tsx
+++ b/ts/components/wallet/card/CardBody.tsx
@@ -39,7 +39,7 @@ type Props = Readonly<{
   mainAction?: (wallet: Wallet) => void;
   lastUsage?: boolean;
   whiteLine?: boolean;
-  navigateToDetails: () => void;
+  navigateToCardTransactions: () => void;
 }>;
 
 export default class CardBody extends React.Component<Props> {
@@ -129,7 +129,7 @@ export default class CardBody extends React.Component<Props> {
           item,
           showMsg: this.props.lastUsage,
           key: "footerRow",
-          navigateToDetails: this.props.navigateToDetails
+          navigateToCardTransactions: this.props.navigateToCardTransactions
         }}
       />
     ];

--- a/ts/components/wallet/card/CardComponent.tsx
+++ b/ts/components/wallet/card/CardComponent.tsx
@@ -99,7 +99,7 @@ type OwnProps = Readonly<{
   headerOnly?: boolean;
   rotated?: boolean;
   customStyle?: any;
-  navigateToDetails: () => void;
+  navigateToCardTransactions: () => void;
 }>;
 
 type Props = OwnProps & ReduxMappedStateProps & ReduxMappedDispatchProps;

--- a/ts/components/wallet/card/CardComponent.tsx
+++ b/ts/components/wallet/card/CardComponent.tsx
@@ -88,7 +88,7 @@ type ReduxMappedDispatchProps = Readonly<{
 }>;
 
 type OwnProps = Readonly<{
-  item: Wallet;
+  wallet: Wallet;
   menu?: boolean;
   favorite?: boolean;
   lastUsage?: boolean;
@@ -99,7 +99,7 @@ type OwnProps = Readonly<{
   headerOnly?: boolean;
   rotated?: boolean;
   customStyle?: any;
-  navigateToCardTransactions: () => void;
+  navigateToWalletTransactions: (item: Wallet) => void;
 }>;
 
 type Props = OwnProps & ReduxMappedStateProps & ReduxMappedDispatchProps;
@@ -125,17 +125,17 @@ class CardComponent extends React.Component<Props> {
     if (this.props.isFavoriteCard) {
       this.props.setFavoriteCard(none);
     } else {
-      this.props.setFavoriteCard(some(this.props.item.idWallet));
+      this.props.setFavoriteCard(some(this.props.wallet.idWallet));
     }
   };
 
   private topRightCorner() {
-    const { item } = this.props;
+    const { wallet } = this.props;
     if (this.props.logoPosition === LogoPosition.TOP) {
       return (
         <Col size={2}>
           {shouldRenderLogo(LogoPosition.TOP, this.props.logoPosition) && (
-            <Logo item={item} />
+            <Logo item={wallet} />
           )}
         </Col>
       );
@@ -186,7 +186,8 @@ class CardComponent extends React.Component<Props> {
                         {
                           text: I18n.t("global.buttons.ok"),
                           style: "destructive",
-                          onPress: () => this.props.deleteWallet(item.idWallet)
+                          onPress: () =>
+                            this.props.deleteWallet(wallet.idWallet)
                         }
                       ],
                       { cancelable: false }
@@ -206,7 +207,7 @@ class CardComponent extends React.Component<Props> {
   }
 
   public render(): React.ReactNode {
-    const { item } = this.props;
+    const { wallet } = this.props;
 
     const cardStyles: ReadonlyArray<ViewStyle> = [
       styles.cardStyle,
@@ -236,7 +237,7 @@ class CardComponent extends React.Component<Props> {
                         CreditCardStyles.largeTextStyle
                       ]}
                     >
-                      {`${HIDDEN_CREDITCARD_NUMBERS}${item.creditCard.pan.slice(
+                      {`${HIDDEN_CREDITCARD_NUMBERS}${wallet.creditCard.pan.slice(
                         -4
                       )}`}
                     </Text>
@@ -264,7 +265,7 @@ const mapStateToProps = (
   return {
     isFavoriteCard: favoriteCard.fold(
       false,
-      walletId => walletId === props.item.idWallet
+      walletId => walletId === props.wallet.idWallet
     )
   };
 };

--- a/ts/components/wallet/card/CardComponent.tsx
+++ b/ts/components/wallet/card/CardComponent.tsx
@@ -15,7 +15,6 @@ import {
   MenuOptions,
   MenuTrigger
 } from "react-native-popup-menu";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
 
 import I18n from "../../../i18n";
@@ -88,9 +87,8 @@ type ReduxMappedDispatchProps = Readonly<{
   deleteWallet: (walletId: number) => void;
 }>;
 
-export type CardProps = Readonly<{
+type OwnProps = Readonly<{
   item: Wallet;
-  navigation: NavigationScreenProp<NavigationState>;
   menu?: boolean;
   favorite?: boolean;
   lastUsage?: boolean;
@@ -101,9 +99,10 @@ export type CardProps = Readonly<{
   headerOnly?: boolean;
   rotated?: boolean;
   customStyle?: any;
+  navigateToDetails: () => void;
 }>;
 
-type Props = CardProps & ReduxMappedStateProps & ReduxMappedDispatchProps;
+type Props = OwnProps & ReduxMappedStateProps & ReduxMappedDispatchProps;
 
 /**
  * Credit card component
@@ -259,7 +258,7 @@ class CardComponent extends React.Component<Props> {
 
 const mapStateToProps = (
   state: GlobalState,
-  props: CardProps
+  props: OwnProps
 ): ReduxMappedStateProps => {
   const favoriteCard = getFavoriteWalletId(state);
   return {

--- a/ts/components/wallet/card/FooterRow.tsx
+++ b/ts/components/wallet/card/FooterRow.tsx
@@ -25,7 +25,7 @@ type ReduxMappedProps = Readonly<{
 type OwnProps = Readonly<{
   item: Wallet;
   showMsg?: boolean;
-  navigateToDetails: () => void;
+  navigateToCardTransactions: () => void;
 }>;
 
 type Props = OwnProps & ReduxMappedProps;
@@ -43,7 +43,7 @@ class FooterRow extends React.Component<Props> {
   };
 
   public render() {
-    const { navigateToDetails } = this.props;
+    const { navigateToCardTransactions } = this.props;
     const { item } = this.props;
     if (this.props.showMsg) {
       // show "last usage" row
@@ -53,7 +53,7 @@ class FooterRow extends React.Component<Props> {
           size={6}
           onPress={() => {
             this.props.selectWallet(item.idWallet);
-            navigateToDetails();
+            navigateToCardTransactions();
           }}
         >
           <Col size={8}>

--- a/ts/components/wallet/card/FooterRow.tsx
+++ b/ts/components/wallet/card/FooterRow.tsx
@@ -9,9 +9,7 @@ import { Text } from "native-base";
 import * as React from "react";
 import { StyleSheet } from "react-native";
 import { Col, Row } from "react-native-easy-grid";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
-import ROUTES from "../../../navigation/routes";
 import { Dispatch } from "../../../store/actions/types";
 import { selectWalletForDetails } from "../../../store/actions/wallet/wallets";
 import variables from "../../../theme/variables";
@@ -25,9 +23,9 @@ type ReduxMappedProps = Readonly<{
 }>;
 
 type OwnProps = Readonly<{
-  navigation: NavigationScreenProp<NavigationState>;
   item: Wallet;
   showMsg?: boolean;
+  navigateToDetails: () => void;
 }>;
 
 type Props = OwnProps & ReduxMappedProps;
@@ -45,7 +43,7 @@ class FooterRow extends React.Component<Props> {
   };
 
   public render() {
-    const { navigate } = this.props.navigation;
+    const { navigateToDetails } = this.props;
     const { item } = this.props;
     if (this.props.showMsg) {
       // show "last usage" row
@@ -55,7 +53,7 @@ class FooterRow extends React.Component<Props> {
           size={6}
           onPress={() => {
             this.props.selectWallet(item.idWallet);
-            navigate(ROUTES.WALLET_CARD_TRANSACTIONS);
+            navigateToDetails();
           }}
         >
           <Col size={8}>

--- a/ts/components/wallet/card/FooterRow.tsx
+++ b/ts/components/wallet/card/FooterRow.tsx
@@ -9,26 +9,19 @@ import { Text } from "native-base";
 import * as React from "react";
 import { StyleSheet } from "react-native";
 import { Col, Row } from "react-native-easy-grid";
-import { connect } from "react-redux";
-import { Dispatch } from "../../../store/actions/types";
-import { selectWalletForDetails } from "../../../store/actions/wallet/wallets";
 import variables from "../../../theme/variables";
 import { Wallet } from "../../../types/pagopa";
 import { buildFormattedLastUsage } from "../../../utils/stringBuilder";
 import IconFont from "../../ui/IconFont";
 import { CreditCardStyles } from "./style";
 
-type ReduxMappedProps = Readonly<{
-  selectWallet: (item: number) => void;
-}>;
-
 type OwnProps = Readonly<{
-  item: Wallet;
+  wallet: Wallet;
   showMsg?: boolean;
-  navigateToCardTransactions: () => void;
+  navigateToWalletTransactions: (item: Wallet) => void;
 }>;
 
-type Props = OwnProps & ReduxMappedProps;
+type Props = OwnProps;
 
 const styles = StyleSheet.create({
   rightAligned: {
@@ -43,18 +36,15 @@ class FooterRow extends React.Component<Props> {
   };
 
   public render() {
-    const { navigateToCardTransactions } = this.props;
-    const { item } = this.props;
+    const { navigateToWalletTransactions } = this.props;
+    const { wallet } = this.props;
     if (this.props.showMsg) {
       // show "last usage" row
       return (
         <Row
           style={CreditCardStyles.rowStyle}
           size={6}
-          onPress={() => {
-            this.props.selectWallet(item.idWallet);
-            navigateToCardTransactions();
-          }}
+          onPress={() => navigateToWalletTransactions(wallet)}
         >
           <Col size={8}>
             <Text
@@ -63,7 +53,7 @@ class FooterRow extends React.Component<Props> {
                 CreditCardStyles.smallTextStyle
               ]}
             >
-              {buildFormattedLastUsage(item)}
+              {buildFormattedLastUsage(wallet)}
             </Text>
           </Col>
           <Col size={1} style={styles.rightAligned}>
@@ -80,11 +70,4 @@ class FooterRow extends React.Component<Props> {
   }
 }
 
-const mapDispatchToProps = (dispatch: Dispatch): ReduxMappedProps => ({
-  selectWallet: (item: number) => dispatch(selectWalletForDetails(item))
-});
-
-export default connect(
-  undefined,
-  mapDispatchToProps
-)(FooterRow);
+export default FooterRow;

--- a/ts/components/wallet/card/Logo.tsx
+++ b/ts/components/wallet/card/Logo.tsx
@@ -40,7 +40,7 @@ export const cardIcons: { [key in CreditCardType]: any } = {
 // shown for all cards -- a future story will take
 // care of switching the images to the actual logos
 // @https://www.pivotaltracker.com/story/show/159651239
-const getCardIcon = (_: Wallet) => {
+const getCardIconFromBrandLogo = (_: Wallet) => {
   return require("../../../../img/wallet/cards-icons/unknown.png");
 };
 
@@ -56,10 +56,11 @@ type Props = Readonly<{
   item: Wallet;
 }>;
 
-export default class Logo extends React.Component<Props> {
-  public render() {
-    return (
-      <Image style={styles.issuerLogo} source={getCardIcon(this.props.item)} />
-    );
-  }
-}
+const Logo: React.SFC<Props> = props => (
+  <Image
+    style={styles.issuerLogo}
+    source={getCardIconFromBrandLogo(props.item)}
+  />
+);
+
+export default Logo;

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -232,7 +232,7 @@ function* initializeApplicationSaga(): IterableIterator<Effect> {
     yield put(clearNotificationPendingMessage());
 
     // Navigate to message details screen
-    yield put(navigateToMessageDetailScreenAction(messageId));
+    yield put(navigateToMessageDetailScreenAction({ messageId }));
     // Push the MAIN navigator in the history to handle the back button
     const navigationState: NavigationState = yield select<GlobalState>(
       navigationStateSelector

--- a/ts/sagas/startup/watchApplicationActivitySaga.ts
+++ b/ts/sagas/startup/watchApplicationActivitySaga.ts
@@ -78,7 +78,7 @@ export function* watchApplicationActivitySaga(): IterableIterator<Effect> {
           // Remove the pending message from the notification state
           yield put(clearNotificationPendingMessage());
           // Navigate to message details screen
-          yield put(navigateToMessageDetailScreenAction(messageId));
+          yield put(navigateToMessageDetailScreenAction({ messageId }));
           // Push the MAIN navigator in the history to handle the back button
           const navigationState: NavigationState = yield select<GlobalState>(
             navigationStateSelector

--- a/ts/sagas/wallet.ts
+++ b/ts/sagas/wallet.ts
@@ -34,6 +34,10 @@ import I18n from "../i18n";
 import ROUTES from "../navigation/routes";
 
 import {
+  navigateToTransactionDetailsScreen,
+  navigateToWalletCheckout3dsScreen
+} from "../store/actions/navigation";
+import {
   goBackOnePaymentState,
   paymentRequestCancel,
   paymentRequestConfirmPaymentMethod,
@@ -111,8 +115,15 @@ import { showToast } from "../utils/showToast";
 import { TranslationKeys } from "../../locales/locales";
 import { attivaAndGetPaymentId } from "./wallet/nodo";
 
-const navigateTo = (routeName: string, params?: object) => {
-  return NavigationActions.navigate({ routeName, params });
+/**
+ * Helper function for navigating to screens that don't accept navigation
+ * parameters.
+ *
+ * For screens that need navigation parameters, use type safe nav action
+ * creators.
+ */
+const navigateTo = (routeName: string) => {
+  return NavigationActions.navigate({ routeName });
 };
 
 function* fetchTransactions(pagoPaClient: PagoPaClient): Iterator<Effect> {
@@ -277,7 +288,7 @@ function* addCreditCard(
     // from pagoPA and needs to be opened in a webview
     const urlWithToken = `${url}&sessionToken=${pagoPaToken.value}`;
     yield put(
-      navigateTo(ROUTES.WALLET_CHECKOUT_3DS_SCREEN, {
+      navigateToWalletCheckout3dsScreen({
         url: urlWithToken
       })
     );
@@ -913,17 +924,8 @@ function* completionHandler(
       // not be shown to the user as of yet)
       yield put(selectTransactionForDetails(newTransaction));
       yield put(selectWalletForDetails(wallet.idWallet)); // for the banner
-      yield put(
-        // TODO: this should use StackActions.reset
-        // to reset the navigation. Right now, the
-        // "back" option is not allowed -- so the user cannot
-        // get back to previous screens, but the navigation
-        // stack should be cleaned right here
-        // @https://www.pivotaltracker.com/story/show/159300579
-        navigateTo(ROUTES.WALLET_TRANSACTION_DETAILS, {
-          paymentCompleted: true
-        })
-      );
+
+      yield put(navigateToTransactionDetailsScreen({ paymentCompleted: true }));
       yield put(resetPaymentState());
     } else {
       yield put(

--- a/ts/sagas/wallet.ts
+++ b/ts/sagas/wallet.ts
@@ -62,8 +62,7 @@ import {
 import {
   fetchTransactionsFailure,
   fetchTransactionsRequest,
-  fetchTransactionsSuccess,
-  selectTransactionForDetails
+  fetchTransactionsSuccess
 } from "../store/actions/wallet/transactions";
 import {
   addCreditCardCompleted,
@@ -73,7 +72,6 @@ import {
   fetchWalletsFailure,
   fetchWalletsRequest,
   fetchWalletsSuccess,
-  selectWalletForDetails,
   walletManagementResetLoadingState,
   walletManagementSetLoadingState
 } from "../store/actions/wallet/wallets";
@@ -919,13 +917,12 @@ function* completionHandler(
       yield call(fetchTransactions, pagoPaClient);
       // FIXME: fetchTransactions could fail
 
-      // use "storeNewTransaction(newTransaction) if it's okay
-      // to have the payment as "pending" (this information will
-      // not be shown to the user as of yet)
-      yield put(selectTransactionForDetails(newTransaction));
-      yield put(selectWalletForDetails(wallet.idWallet)); // for the banner
-
-      yield put(navigateToTransactionDetailsScreen({ paymentCompleted: true }));
+      yield put(
+        navigateToTransactionDetailsScreen({
+          transaction: newTransaction,
+          isPaymentCompletedTransaction: true
+        })
+      );
       yield put(resetPaymentState());
     } else {
       yield put(

--- a/ts/screens/wallet/AddPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/AddPaymentMethodScreen.tsx
@@ -82,7 +82,7 @@ class AddPaymentMethodScreen extends React.PureComponent<Props> {
         </AppHeader>
         {this.isInTransaction() ? (
           <Content noPadded={true}>
-            <PaymentBannerComponent navigation={this.props.navigation} />
+            <PaymentBannerComponent />
             <View style={WalletStyles.paddedLR}>
               <View spacer={true} large={true} />
               {this.isInTransaction() && (

--- a/ts/screens/wallet/Checkout3DsScreen.tsx
+++ b/ts/screens/wallet/Checkout3DsScreen.tsx
@@ -7,11 +7,15 @@ import { RefreshIndicator } from "../../components/ui/RefreshIndicator";
 import { Dispatch } from "../../store/actions/types";
 import { addCreditCardCompleted } from "../../store/actions/wallet/wallets";
 
+type NavigationParams = Readonly<{
+  url: string;
+}>;
+
 type ReduxMappedProps = Readonly<{
   addCreditCardCompleted: () => void;
 }>;
 
-type Props = ReduxMappedProps & NavigationInjectedProps;
+type Props = ReduxMappedProps & NavigationInjectedProps<NavigationParams>;
 
 type State = {
   isWebViewLoading: boolean;

--- a/ts/screens/wallet/ConfirmCardDetailsScreen.tsx
+++ b/ts/screens/wallet/ConfirmCardDetailsScreen.tsx
@@ -110,7 +110,7 @@ class ConfirmCardDetailsScreen extends React.Component<Props, State> {
             menu={false}
             favorite={false}
             lastUsage={false}
-            navigateToDetails={() =>
+            navigateToCardTransactions={() =>
               this.props.navigation.navigate(ROUTES.WALLET_CARD_TRANSACTIONS)
             }
           />

--- a/ts/screens/wallet/ConfirmCardDetailsScreen.tsx
+++ b/ts/screens/wallet/ConfirmCardDetailsScreen.tsx
@@ -23,7 +23,7 @@ import AppHeader from "../../components/ui/AppHeader";
 import FooterWithButtons from "../../components/ui/FooterWithButtons";
 import CardComponent from "../../components/wallet/card/CardComponent";
 import I18n from "../../i18n";
-import ROUTES from "../../navigation/routes";
+import { navigateToWalletTransactionsScreen } from "../../store/actions/navigation";
 import { Dispatch } from "../../store/actions/types";
 import { addCreditCardRequest } from "../../store/actions/wallet/wallets";
 import { GlobalState } from "../../store/reducers/types";
@@ -106,12 +106,14 @@ class ConfirmCardDetailsScreen extends React.Component<Props, State> {
         <Content>
           <H1> {I18n.t("wallet.saveCard.title")} </H1>
           <CardComponent
-            item={this.props.wallet}
+            wallet={this.props.wallet}
             menu={false}
             favorite={false}
             lastUsage={false}
-            navigateToCardTransactions={() =>
-              this.props.navigation.navigate(ROUTES.WALLET_CARD_TRANSACTIONS)
+            navigateToWalletTransactions={(wallet: Wallet) =>
+              this.props.navigation.dispatch(
+                navigateToWalletTransactionsScreen({ selectedWallet: wallet })
+              )
             }
           />
           <View spacer={true} />

--- a/ts/screens/wallet/ConfirmCardDetailsScreen.tsx
+++ b/ts/screens/wallet/ConfirmCardDetailsScreen.tsx
@@ -15,20 +15,25 @@ import {
 import * as React from "react";
 import { Switch } from "react-native";
 import { Col, Grid } from "react-native-easy-grid";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationInjectedProps } from "react-navigation";
 import { connect } from "react-redux";
 import GoBackButton from "../../components/GoBackButton";
 import { InstabugButtons } from "../../components/InstabugButtons";
 import AppHeader from "../../components/ui/AppHeader";
 import FooterWithButtons from "../../components/ui/FooterWithButtons";
-import CardComponent from "../../components/wallet/card";
+import CardComponent from "../../components/wallet/card/CardComponent";
 import I18n from "../../i18n";
+import ROUTES from "../../navigation/routes";
 import { Dispatch } from "../../store/actions/types";
 import { addCreditCardRequest } from "../../store/actions/wallet/wallets";
 import { GlobalState } from "../../store/reducers/types";
 import { getNewCreditCard } from "../../store/reducers/wallet/wallets";
 import { CreditCard, Wallet } from "../../types/pagopa";
 import { UNKNOWN_CARD } from "../../types/unknown";
+
+type NavigationParams = Readonly<{
+  paymentCompleted: boolean;
+}>;
 
 type ReduxMappedStateProps = Readonly<{
   wallet: Wallet;
@@ -38,11 +43,9 @@ type ReduMappedDispatchProps = Readonly<{
   addCreditCard: (creditCard: CreditCard, favorite: boolean) => void;
 }>;
 
-type OwnProps = Readonly<{
-  navigation: NavigationScreenProp<NavigationState>;
-}>;
-
-type Props = OwnProps & ReduxMappedStateProps & ReduMappedDispatchProps;
+type Props = ReduxMappedStateProps &
+  ReduMappedDispatchProps &
+  NavigationInjectedProps<NavigationParams>;
 
 type State = Readonly<{
   favorite: boolean;
@@ -103,11 +106,13 @@ class ConfirmCardDetailsScreen extends React.Component<Props, State> {
         <Content>
           <H1> {I18n.t("wallet.saveCard.title")} </H1>
           <CardComponent
-            navigation={this.props.navigation}
             item={this.props.wallet}
             menu={false}
             favorite={false}
             lastUsage={false}
+            navigateToDetails={() =>
+              this.props.navigation.navigate(ROUTES.WALLET_CARD_TRANSACTIONS)
+            }
           />
           <View spacer={true} />
           <Grid>

--- a/ts/screens/wallet/TransactionDetailsScreen.tsx
+++ b/ts/screens/wallet/TransactionDetailsScreen.tsx
@@ -24,6 +24,7 @@ import { CardEnum } from "../../components/wallet/WalletLayout";
 import WalletLayout from "../../components/wallet/WalletLayout";
 import I18n from "../../i18n";
 import ROUTES from "../../navigation/routes";
+import { navigateToTransactionDetailsScreen } from "../../store/actions/navigation";
 import { GlobalState } from "../../store/reducers/types";
 import { transactionForDetailsSelector } from "../../store/reducers/wallet/transactions";
 import { selectedWalletSelector } from "../../store/reducers/wallet/wallets";
@@ -146,7 +147,9 @@ class TransactionDetailsScreen extends React.Component<Props> {
           this.props.navigation.navigate(ROUTES.PAYMENT_SCAN_QR_CODE)
         }
         navigateToCardTransactions={() =>
-          this.props.navigation.navigate(ROUTES.WALLET_CARD_TRANSACTIONS)
+          this.props.navigation.dispatch(
+            navigateToTransactionDetailsScreen({ paymentCompleted: false })
+          )
         }
       >
         <Content

--- a/ts/screens/wallet/TransactionDetailsScreen.tsx
+++ b/ts/screens/wallet/TransactionDetailsScreen.tsx
@@ -33,12 +33,16 @@ import { Transaction } from "../../types/pagopa";
 import { UNKNOWN_CARD, UNKNOWN_TRANSACTION } from "../../types/unknown";
 import { buildAmount, centsToAmount } from "../../utils/stringBuilder";
 
+type NavigationParams = Readonly<{
+  paymentCompleted: boolean;
+}>;
+
 type ReduxMappedProps = Readonly<{
   transaction: Transaction;
   selectedWallet: Wallet;
 }>;
 
-type Props = ReduxMappedProps & NavigationInjectedProps;
+type Props = ReduxMappedProps & NavigationInjectedProps<NavigationParams>;
 
 /**
  * isTransactionStarted will be true when the user accepted to proceed with a transaction
@@ -64,11 +68,7 @@ class TransactionDetailsScreen extends React.Component<Props> {
    * (the user displays the screen during the process of identify and accept a transaction)
    * then the "Thank you message" is displayed
    */
-  private getSubHeader() {
-    const paymentCompleted = this.props.navigation.getParam(
-      "paymentCompleted",
-      false
-    );
+  private getSubHeader(paymentCompleted: boolean) {
     return paymentCompleted ? (
       <View>
         <Grid>
@@ -135,11 +135,19 @@ class TransactionDetailsScreen extends React.Component<Props> {
     return (
       <WalletLayout
         title={I18n.t("wallet.transaction")}
-        navigation={this.props.navigation}
-        headerContents={this.getSubHeader()}
+        headerContents={this.getSubHeader(paymentCompleted)}
         cardType={{ type: CardEnum.HEADER, card: this.props.selectedWallet }}
         showPayButton={false}
         allowGoBack={!paymentCompleted}
+        navigateToWalletList={() =>
+          this.props.navigation.navigate(ROUTES.WALLET_LIST)
+        }
+        navigateToScanQrCode={() =>
+          this.props.navigation.navigate(ROUTES.PAYMENT_SCAN_QR_CODE)
+        }
+        navigateToCardTransactions={() =>
+          this.props.navigation.navigate(ROUTES.WALLET_CARD_TRANSACTIONS)
+        }
       >
         <Content
           scrollEnabled={false}

--- a/ts/screens/wallet/TransactionDetailsScreen.tsx
+++ b/ts/screens/wallet/TransactionDetailsScreen.tsx
@@ -11,39 +11,37 @@
  * TODO: insert contextual help to the Text link related to the fee
  *      @https://www.pivotaltracker.com/n/projects/2048617/stories/158108270
  */
-import * as React from "react";
-
 import { Content, H1, H3, Text, View } from "native-base";
+import * as React from "react";
 import { StyleSheet } from "react-native";
 import { Col, Grid, Row } from "react-native-easy-grid";
 import { NavigationInjectedProps } from "react-navigation";
 import { connect } from "react-redux";
+
 import { WalletStyles } from "../../components/styles/wallet";
 import IconFont from "../../components/ui/IconFont";
 import { CardEnum } from "../../components/wallet/WalletLayout";
 import WalletLayout from "../../components/wallet/WalletLayout";
 import I18n from "../../i18n";
 import ROUTES from "../../navigation/routes";
-import { navigateToTransactionDetailsScreen } from "../../store/actions/navigation";
+import { navigateToWalletTransactionsScreen } from "../../store/actions/navigation";
 import { GlobalState } from "../../store/reducers/types";
-import { transactionForDetailsSelector } from "../../store/reducers/wallet/transactions";
-import { selectedWalletSelector } from "../../store/reducers/wallet/wallets";
+import { getWalletsById } from "../../store/reducers/wallet/wallets";
 import variables from "../../theme/variables";
 import { Wallet } from "../../types/pagopa";
 import { Transaction } from "../../types/pagopa";
-import { UNKNOWN_CARD, UNKNOWN_TRANSACTION } from "../../types/unknown";
 import { buildAmount, centsToAmount } from "../../utils/stringBuilder";
 
 type NavigationParams = Readonly<{
-  paymentCompleted: boolean;
-}>;
-
-type ReduxMappedProps = Readonly<{
+  isPaymentCompletedTransaction: boolean;
   transaction: Transaction;
-  selectedWallet: Wallet;
 }>;
 
-type Props = ReduxMappedProps & NavigationInjectedProps<NavigationParams>;
+type ReduxInjectedProps = Readonly<{
+  wallets: ReturnType<typeof getWalletsById>;
+}>;
+
+type Props = ReduxInjectedProps & NavigationInjectedProps<NavigationParams>;
 
 /**
  * isTransactionStarted will be true when the user accepted to proceed with a transaction
@@ -116,9 +114,11 @@ class TransactionDetailsScreen extends React.Component<Props> {
   }
 
   public render(): React.ReactNode {
-    const { transaction } = this.props;
-    const paymentCompleted = this.props.navigation.getParam(
-      "paymentCompleted",
+    const transaction = this.props.navigation.getParam("transaction");
+
+    // whether this transaction is the result of a just completed payment
+    const isPaymentCompletedTransaction = this.props.navigation.getParam(
+      "isPaymentCompletedTransaction",
       false
     );
     const amount = buildAmount(centsToAmount(transaction.amount.amount));
@@ -133,22 +133,32 @@ class TransactionDetailsScreen extends React.Component<Props> {
       centsToAmount(transaction.grandTotal.amount)
     );
 
+    // FIXME: in case the wallet for this transaction has been deleted, display
+    //        a message in the wallet layout instead of an empty space
+    const transactionWallet = this.props.wallets[transaction.idWallet];
+
     return (
       <WalletLayout
         title={I18n.t("wallet.transaction")}
-        headerContents={this.getSubHeader(paymentCompleted)}
-        cardType={{ type: CardEnum.HEADER, card: this.props.selectedWallet }}
+        headerContents={this.getSubHeader(isPaymentCompletedTransaction)}
+        cardType={
+          transactionWallet
+            ? { type: CardEnum.HEADER, card: transactionWallet }
+            : { type: CardEnum.NONE }
+        }
         showPayButton={false}
-        allowGoBack={!paymentCompleted}
+        allowGoBack={!isPaymentCompletedTransaction}
         navigateToWalletList={() =>
           this.props.navigation.navigate(ROUTES.WALLET_LIST)
         }
         navigateToScanQrCode={() =>
           this.props.navigation.navigate(ROUTES.PAYMENT_SCAN_QR_CODE)
         }
-        navigateToCardTransactions={() =>
+        navigateToWalletTransactions={(selectedWallet: Wallet) =>
           this.props.navigation.dispatch(
-            navigateToTransactionDetailsScreen({ paymentCompleted: false })
+            navigateToWalletTransactionsScreen({
+              selectedWallet
+            })
           )
         }
       >
@@ -163,7 +173,7 @@ class TransactionDetailsScreen extends React.Component<Props> {
                 name="io-close"
                 size={variables.iconSizeBase}
                 onPress={() =>
-                  paymentCompleted
+                  isPaymentCompletedTransaction
                     ? this.props.navigation.navigate(ROUTES.WALLET_HOME)
                     : this.props.navigation.goBack()
                 }
@@ -206,11 +216,9 @@ class TransactionDetailsScreen extends React.Component<Props> {
     );
   }
 }
-const mapStateToProps = (state: GlobalState): ReduxMappedProps => ({
-  transaction: transactionForDetailsSelector(state).getOrElse(
-    UNKNOWN_TRANSACTION
-  ),
-  selectedWallet: selectedWalletSelector(state).getOrElse(UNKNOWN_CARD)
+
+export const mapStateToProps = (state: GlobalState): ReduxInjectedProps => ({
+  wallets: getWalletsById(state)
 });
 
 export default connect(mapStateToProps)(TransactionDetailsScreen);

--- a/ts/screens/wallet/TransactionsScreen.tsx
+++ b/ts/screens/wallet/TransactionsScreen.tsx
@@ -6,11 +6,7 @@ import * as React from "react";
 import I18n from "../../i18n";
 
 import { Text, View } from "native-base";
-import {
-  NavigationInjectedProps,
-  NavigationScreenProp,
-  NavigationState
-} from "react-navigation";
+import { NavigationInjectedProps } from "react-navigation";
 
 import { connect } from "react-redux";
 import { withLoadingSpinner } from "../../components/helpers/withLoadingSpinner";
@@ -20,30 +16,24 @@ import TransactionsList, {
 } from "../../components/wallet/TransactionsList";
 import { CardEnum } from "../../components/wallet/WalletLayout";
 import WalletLayout from "../../components/wallet/WalletLayout";
+import ROUTES from "../../navigation/routes";
 import { createLoadingSelector } from "../../store/reducers/loading";
 import { GlobalState } from "../../store/reducers/types";
 import { selectedWalletSelector } from "../../store/reducers/wallet/wallets";
 import { Wallet } from "../../types/pagopa";
 import { UNKNOWN_CARD } from "../../types/unknown";
 
-interface ParamType {
-  readonly card: Wallet;
-}
-
-interface StateParams extends NavigationState {
-  readonly params: ParamType;
-}
-
-interface OwnProps {
-  readonly navigation: NavigationScreenProp<StateParams>;
-}
+type NavigationParams = Readonly<{
+  paymentCompleted: boolean;
+  card: Wallet;
+}>;
 
 type ReduxMappedProps = Readonly<{
   selectedWallet: Wallet;
   isLoading: boolean;
 }>;
 
-type Props = ReduxMappedProps & OwnProps & NavigationInjectedProps;
+type Props = ReduxMappedProps & NavigationInjectedProps<NavigationParams>;
 
 class TransactionsScreen extends React.Component<Props, never> {
   public render(): React.ReactNode {
@@ -61,16 +51,26 @@ class TransactionsScreen extends React.Component<Props, never> {
     return (
       <WalletLayout
         title={I18n.t("wallet.paymentMethod")}
-        navigation={this.props.navigation}
         showPayButton={false}
         headerContents={headerContents}
         cardType={{ type: CardEnum.FULL, card: this.props.selectedWallet }}
+        navigateToWalletList={() =>
+          this.props.navigation.navigate(ROUTES.WALLET_LIST)
+        }
+        navigateToScanQrCode={() =>
+          this.props.navigation.navigate(ROUTES.PAYMENT_SCAN_QR_CODE)
+        }
+        navigateToCardTransactions={() =>
+          this.props.navigation.navigate(ROUTES.WALLET_CARD_TRANSACTIONS)
+        }
       >
         <TransactionsList
           title={I18n.t("wallet.transactions")}
           totalAmount={I18n.t("wallet.total")}
-          navigation={this.props.navigation}
           display={TransactionsDisplayed.BY_WALLET}
+          navigateToTransactionDetails={() =>
+            this.props.navigation.navigate(ROUTES.WALLET_TRANSACTION_DETAILS)
+          }
         />
       </WalletLayout>
     );

--- a/ts/screens/wallet/TransactionsScreen.tsx
+++ b/ts/screens/wallet/TransactionsScreen.tsx
@@ -17,6 +17,7 @@ import TransactionsList, {
 import { CardEnum } from "../../components/wallet/WalletLayout";
 import WalletLayout from "../../components/wallet/WalletLayout";
 import ROUTES from "../../navigation/routes";
+import { navigateToTransactionDetailsScreen } from "../../store/actions/navigation";
 import { createLoadingSelector } from "../../store/reducers/loading";
 import { GlobalState } from "../../store/reducers/types";
 import { selectedWalletSelector } from "../../store/reducers/wallet/wallets";
@@ -69,7 +70,11 @@ class TransactionsScreen extends React.Component<Props, never> {
           totalAmount={I18n.t("wallet.total")}
           display={TransactionsDisplayed.BY_WALLET}
           navigateToTransactionDetails={() =>
-            this.props.navigation.navigate(ROUTES.WALLET_TRANSACTION_DETAILS)
+            this.props.navigation.dispatch(
+              navigateToTransactionDetailsScreen({
+                paymentCompleted: false
+              })
+            )
           }
         />
       </WalletLayout>

--- a/ts/screens/wallet/TransactionsScreen.tsx
+++ b/ts/screens/wallet/TransactionsScreen.tsx
@@ -17,27 +17,27 @@ import TransactionsList, {
 import { CardEnum } from "../../components/wallet/WalletLayout";
 import WalletLayout from "../../components/wallet/WalletLayout";
 import ROUTES from "../../navigation/routes";
-import { navigateToTransactionDetailsScreen } from "../../store/actions/navigation";
+import {
+  navigateToTransactionDetailsScreen,
+  navigateToWalletTransactionsScreen
+} from "../../store/actions/navigation";
 import { createLoadingSelector } from "../../store/reducers/loading";
 import { GlobalState } from "../../store/reducers/types";
-import { selectedWalletSelector } from "../../store/reducers/wallet/wallets";
 import { Wallet } from "../../types/pagopa";
-import { UNKNOWN_CARD } from "../../types/unknown";
 
 type NavigationParams = Readonly<{
-  paymentCompleted: boolean;
-  card: Wallet;
+  selectedWallet: Wallet;
 }>;
 
 type ReduxMappedProps = Readonly<{
-  selectedWallet: Wallet;
   isLoading: boolean;
 }>;
 
 type Props = ReduxMappedProps & NavigationInjectedProps<NavigationParams>;
 
-class TransactionsScreen extends React.Component<Props, never> {
+class TransactionsScreen extends React.Component<Props> {
   public render(): React.ReactNode {
+    const selectedWallet = this.props.navigation.getParam("selectedWallet");
     const headerContents = (
       <View>
         <View style={WalletStyles.walletBannerText}>
@@ -54,25 +54,28 @@ class TransactionsScreen extends React.Component<Props, never> {
         title={I18n.t("wallet.paymentMethod")}
         showPayButton={false}
         headerContents={headerContents}
-        cardType={{ type: CardEnum.FULL, card: this.props.selectedWallet }}
+        cardType={{ type: CardEnum.FULL, card: selectedWallet }}
         navigateToWalletList={() =>
           this.props.navigation.navigate(ROUTES.WALLET_LIST)
         }
         navigateToScanQrCode={() =>
           this.props.navigation.navigate(ROUTES.PAYMENT_SCAN_QR_CODE)
         }
-        navigateToCardTransactions={() =>
-          this.props.navigation.navigate(ROUTES.WALLET_CARD_TRANSACTIONS)
+        navigateToWalletTransactions={(wallet: Wallet) =>
+          this.props.navigation.dispatch(
+            navigateToWalletTransactionsScreen({ selectedWallet: wallet })
+          )
         }
       >
         <TransactionsList
           title={I18n.t("wallet.transactions")}
           totalAmount={I18n.t("wallet.total")}
           display={TransactionsDisplayed.BY_WALLET}
-          navigateToTransactionDetails={() =>
+          navigateToTransactionDetails={transaction =>
             this.props.navigation.dispatch(
               navigateToTransactionDetailsScreen({
-                paymentCompleted: false
+                transaction,
+                isPaymentCompletedTransaction: false
               })
             )
           }
@@ -83,7 +86,6 @@ class TransactionsScreen extends React.Component<Props, never> {
 }
 
 const mapStateToProps = (state: GlobalState): ReduxMappedProps => ({
-  selectedWallet: selectedWalletSelector(state).getOrElse(UNKNOWN_CARD),
   isLoading: createLoadingSelector(["WALLET_MANAGEMENT_LOAD"])(state)
 });
 

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -20,6 +20,7 @@ import WalletLayout from "../../components/wallet/WalletLayout";
 import { DEFAULT_APPLICATION_NAME } from "../../config";
 import I18n from "../../i18n";
 import ROUTES from "../../navigation/routes";
+import { navigateToTransactionDetailsScreen } from "../../store/actions/navigation";
 import { Dispatch } from "../../store/actions/types";
 import { fetchTransactionsRequest } from "../../store/actions/wallet/transactions";
 import { fetchWalletsRequest } from "../../store/actions/wallet/wallets";
@@ -196,7 +197,9 @@ class WalletHomeScreen extends React.Component<Props, never> {
           this.props.navigation.navigate(ROUTES.PAYMENT_SCAN_QR_CODE)
         }
         navigateToCardTransactions={() =>
-          this.props.navigation.navigate(ROUTES.WALLET_CARD_TRANSACTIONS)
+          this.props.navigation.dispatch(
+            navigateToTransactionDetailsScreen({ paymentCompleted: false })
+          )
         }
       >
         <TransactionsList
@@ -204,7 +207,9 @@ class WalletHomeScreen extends React.Component<Props, never> {
           totalAmount={I18n.t("wallet.total")}
           display={TransactionsDisplayed.LATEST}
           navigateToTransactionDetails={() =>
-            this.props.navigation.navigate(ROUTES.WALLET_TRANSACTION_DETAILS)
+            this.props.navigation.dispatch(
+              navigateToTransactionDetailsScreen({ paymentCompleted: false })
+            )
           }
         />
       </WalletLayout>

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -186,16 +186,26 @@ class WalletHomeScreen extends React.Component<Props, never> {
     return (
       <WalletLayout
         title={DEFAULT_APPLICATION_NAME}
-        navigation={this.props.navigation}
         headerContents={headerContents}
         cardType={cardType}
         allowGoBack={false}
+        navigateToWalletList={() =>
+          this.props.navigation.navigate(ROUTES.WALLET_LIST)
+        }
+        navigateToScanQrCode={() =>
+          this.props.navigation.navigate(ROUTES.PAYMENT_SCAN_QR_CODE)
+        }
+        navigateToCardTransactions={() =>
+          this.props.navigation.navigate(ROUTES.WALLET_CARD_TRANSACTIONS)
+        }
       >
         <TransactionsList
           title={I18n.t("wallet.latestTransactions")}
           totalAmount={I18n.t("wallet.total")}
-          navigation={this.props.navigation}
           display={TransactionsDisplayed.LATEST}
+          navigateToTransactionDetails={() =>
+            this.props.navigation.navigate(ROUTES.WALLET_TRANSACTION_DETAILS)
+          }
         />
       </WalletLayout>
     );

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -20,14 +20,17 @@ import WalletLayout from "../../components/wallet/WalletLayout";
 import { DEFAULT_APPLICATION_NAME } from "../../config";
 import I18n from "../../i18n";
 import ROUTES from "../../navigation/routes";
-import { navigateToTransactionDetailsScreen } from "../../store/actions/navigation";
+import {
+  navigateToTransactionDetailsScreen,
+  navigateToWalletTransactionsScreen
+} from "../../store/actions/navigation";
 import { Dispatch } from "../../store/actions/types";
 import { fetchTransactionsRequest } from "../../store/actions/wallet/transactions";
 import { fetchWalletsRequest } from "../../store/actions/wallet/wallets";
 import { createLoadingSelector } from "../../store/reducers/loading";
 import { GlobalState } from "../../store/reducers/types";
 import { walletsSelector } from "../../store/reducers/wallet/wallets";
-import { Wallet } from "../../types/pagopa";
+import { Transaction, Wallet } from "../../types/pagopa";
 
 type ReduxMappedStateProps =
   | Readonly<{
@@ -196,9 +199,11 @@ class WalletHomeScreen extends React.Component<Props, never> {
         navigateToScanQrCode={() =>
           this.props.navigation.navigate(ROUTES.PAYMENT_SCAN_QR_CODE)
         }
-        navigateToCardTransactions={() =>
+        navigateToWalletTransactions={(selectedWallet: Wallet) =>
           this.props.navigation.dispatch(
-            navigateToTransactionDetailsScreen({ paymentCompleted: false })
+            navigateToWalletTransactionsScreen({
+              selectedWallet
+            })
           )
         }
       >
@@ -206,9 +211,12 @@ class WalletHomeScreen extends React.Component<Props, never> {
           title={I18n.t("wallet.latestTransactions")}
           totalAmount={I18n.t("wallet.total")}
           display={TransactionsDisplayed.LATEST}
-          navigateToTransactionDetails={() =>
+          navigateToTransactionDetails={(transaction: Transaction) =>
             this.props.navigation.dispatch(
-              navigateToTransactionDetailsScreen({ paymentCompleted: false })
+              navigateToTransactionDetailsScreen({
+                transaction,
+                isPaymentCompletedTransaction: false
+              })
             )
           }
         />

--- a/ts/screens/wallet/WalletsScreen.tsx
+++ b/ts/screens/wallet/WalletsScreen.tsx
@@ -16,6 +16,7 @@ import { connect } from "react-redux";
 import { withLoadingSpinner } from "../../components/helpers/withLoadingSpinner";
 import CardComponent from "../../components/wallet/card/CardComponent";
 import ROUTES from "../../navigation/routes";
+import { navigateToWalletTransactionsScreen } from "../../store/actions/navigation";
 import { createLoadingSelector } from "../../store/reducers/loading";
 import { GlobalState } from "../../store/reducers/types";
 import { walletsSelector } from "../../store/reducers/wallet/wallets";
@@ -51,8 +52,10 @@ class WalletsScreen extends React.Component<Props, never> {
         navigateToScanQrCode={() =>
           this.props.navigation.navigate(ROUTES.PAYMENT_SCAN_QR_CODE)
         }
-        navigateToCardTransactions={() =>
-          this.props.navigation.navigate(ROUTES.WALLET_CARD_TRANSACTIONS)
+        navigateToWalletTransactions={(selectedWallet: Wallet) =>
+          this.props.navigation.dispatch(
+            navigateToWalletTransactionsScreen({ selectedWallet })
+          )
         }
       >
         <Content style={[WalletStyles.padded, WalletStyles.header]}>
@@ -61,10 +64,10 @@ class WalletsScreen extends React.Component<Props, never> {
             dataArray={this.props.wallets as any[]} // tslint:disable-line
             renderRow={(item): React.ReactElement<any> => (
               <CardComponent
-                item={item}
-                navigateToCardTransactions={() =>
-                  this.props.navigation.navigate(
-                    ROUTES.WALLET_CARD_TRANSACTIONS
+                wallet={item}
+                navigateToWalletTransactions={(selectedWallet: Wallet) =>
+                  this.props.navigation.dispatch(
+                    navigateToWalletTransactionsScreen({ selectedWallet })
                   )
                 }
               />

--- a/ts/screens/wallet/WalletsScreen.tsx
+++ b/ts/screens/wallet/WalletsScreen.tsx
@@ -14,7 +14,7 @@ import { Button } from "native-base";
 import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
 import { withLoadingSpinner } from "../../components/helpers/withLoadingSpinner";
-import CardComponent from "../../components/wallet/card";
+import CardComponent from "../../components/wallet/card/CardComponent";
 import ROUTES from "../../navigation/routes";
 import { createLoadingSelector } from "../../store/reducers/loading";
 import { GlobalState } from "../../store/reducers/types";
@@ -44,15 +44,30 @@ class WalletsScreen extends React.Component<Props, never> {
     return (
       <WalletLayout
         title={I18n.t("wallet.paymentMethods")}
-        navigation={this.props.navigation}
         headerContents={headerContents}
+        navigateToWalletList={() =>
+          this.props.navigation.navigate(ROUTES.WALLET_LIST)
+        }
+        navigateToScanQrCode={() =>
+          this.props.navigation.navigate(ROUTES.PAYMENT_SCAN_QR_CODE)
+        }
+        navigateToCardTransactions={() =>
+          this.props.navigation.navigate(ROUTES.WALLET_CARD_TRANSACTIONS)
+        }
       >
         <Content style={[WalletStyles.padded, WalletStyles.header]}>
           <List
             removeClippedSubviews={false}
             dataArray={this.props.wallets as any[]} // tslint:disable-line
             renderRow={(item): React.ReactElement<any> => (
-              <CardComponent navigation={this.props.navigation} item={item} />
+              <CardComponent
+                item={item}
+                navigateToDetails={() =>
+                  this.props.navigation.navigate(
+                    ROUTES.WALLET_CARD_TRANSACTIONS
+                  )
+                }
+              />
             )}
           />
           <View spacer={true} />

--- a/ts/screens/wallet/WalletsScreen.tsx
+++ b/ts/screens/wallet/WalletsScreen.tsx
@@ -62,7 +62,7 @@ class WalletsScreen extends React.Component<Props, never> {
             renderRow={(item): React.ReactElement<any> => (
               <CardComponent
                 item={item}
-                navigateToDetails={() =>
+                navigateToCardTransactions={() =>
                   this.props.navigation.navigate(
                     ROUTES.WALLET_CARD_TRANSACTIONS
                   )

--- a/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
@@ -36,7 +36,7 @@ import AppHeader from "../../../components/ui/AppHeader";
 import CardComponent from "../../../components/wallet/card/CardComponent";
 import PaymentBannerComponent from "../../../components/wallet/PaymentBannerComponent";
 import I18n from "../../../i18n";
-import ROUTES from "../../../navigation/routes";
+import { navigateToWalletTransactionsScreen } from "../../../store/actions/navigation";
 import { Dispatch } from "../../../store/actions/types";
 import { paymentRequestTransactionSummaryFromBanner } from "../../../store/actions/wallet/payment";
 import {
@@ -153,12 +153,14 @@ class ConfirmPaymentMethodScreen extends React.Component<Props, never> {
             <H1>{I18n.t("wallet.ConfirmPayment.askConfirm")}</H1>
             <View spacer={true} />
             <CardComponent
-              item={this.props.wallet}
+              wallet={this.props.wallet}
               menu={false}
               favorite={false}
               lastUsage={false}
-              navigateToCardTransactions={() =>
-                this.props.navigation.navigate(ROUTES.WALLET_CARD_TRANSACTIONS)
+              navigateToWalletTransactions={(selectedWallet: Wallet) =>
+                this.props.navigation.dispatch(
+                  navigateToWalletTransactionsScreen({ selectedWallet })
+                )
               }
             />
             <View spacer={true} large={true} />

--- a/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
@@ -157,7 +157,7 @@ class ConfirmPaymentMethodScreen extends React.Component<Props, never> {
               menu={false}
               favorite={false}
               lastUsage={false}
-              navigateToDetails={() =>
+              navigateToCardTransactions={() =>
                 this.props.navigation.navigate(ROUTES.WALLET_CARD_TRANSACTIONS)
               }
             />

--- a/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
@@ -25,7 +25,7 @@ import {
 import * as React from "react";
 import { StyleSheet } from "react-native";
 import { Col, Grid, Row } from "react-native-easy-grid";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationInjectedProps } from "react-navigation";
 import { connect } from "react-redux";
 import GoBackButton from "../../../components/GoBackButton";
 import { withErrorModal } from "../../../components/helpers/withErrorModal";
@@ -33,9 +33,10 @@ import { withLoadingSpinner } from "../../../components/helpers/withLoadingSpinn
 import { InstabugButtons } from "../../../components/InstabugButtons";
 import { WalletStyles } from "../../../components/styles/wallet";
 import AppHeader from "../../../components/ui/AppHeader";
-import CardComponent from "../../../components/wallet/card";
+import CardComponent from "../../../components/wallet/card/CardComponent";
 import PaymentBannerComponent from "../../../components/wallet/PaymentBannerComponent";
 import I18n from "../../../i18n";
+import ROUTES from "../../../navigation/routes";
 import { Dispatch } from "../../../store/actions/types";
 import { paymentRequestTransactionSummaryFromBanner } from "../../../store/actions/wallet/payment";
 import {
@@ -61,6 +62,10 @@ import { mapErrorCodeToMessage } from "../../../types/errors";
 import { Psp, Wallet } from "../../../types/pagopa";
 import { UNKNOWN_AMOUNT } from "../../../types/unknown";
 import { buildAmount } from "../../../utils/stringBuilder";
+
+type NavigationParams = Readonly<{
+  paymentCompleted: boolean;
+}>;
 
 type ReduxMappedStateProps = Readonly<{
   isLoading: boolean;
@@ -93,11 +98,9 @@ type ReduxMappedDispatchProps = Readonly<{
   onCancel: () => void;
 }>;
 
-type OwnProps = Readonly<{
-  navigation: NavigationScreenProp<NavigationState>;
-}>;
-
-type Props = OwnProps & ReduxMappedStateProps & ReduxMappedDispatchProps;
+type Props = ReduxMappedStateProps &
+  ReduxMappedDispatchProps &
+  NavigationInjectedProps<NavigationParams>;
 
 const styles = StyleSheet.create({
   child: {
@@ -144,17 +147,19 @@ class ConfirmPaymentMethodScreen extends React.Component<Props, never> {
         </AppHeader>
 
         <Content noPadded={true}>
-          <PaymentBannerComponent navigation={this.props.navigation} />
+          <PaymentBannerComponent />
           <View style={WalletStyles.paddedLR}>
             <View spacer={true} extralarge={true} />
             <H1>{I18n.t("wallet.ConfirmPayment.askConfirm")}</H1>
             <View spacer={true} />
             <CardComponent
-              navigation={this.props.navigation}
               item={this.props.wallet}
               menu={false}
               favorite={false}
               lastUsage={false}
+              navigateToDetails={() =>
+                this.props.navigation.navigate(ROUTES.WALLET_CARD_TRANSACTIONS)
+              }
             />
             <View spacer={true} large={true} />
             <Grid>

--- a/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
@@ -142,7 +142,7 @@ class PickPaymentMethodScreen extends React.Component<Props> {
                   lastUsage={false}
                   mainAction={confirmPaymentMethod}
                   logoPosition={LogoPosition.TOP}
-                  navigateToDetails={() =>
+                  navigateToCardTransactions={() =>
                     this.props.navigation.navigate(
                       ROUTES.WALLET_CARD_TRANSACTIONS
                     )

--- a/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
@@ -14,14 +14,14 @@ import {
   View
 } from "native-base";
 import * as React from "react";
-import { NavigationScreenProp, NavigationState } from "react-navigation";
+import { NavigationInjectedProps } from "react-navigation";
 import { connect } from "react-redux";
 import GoBackButton from "../../../components/GoBackButton";
 import { InstabugButtons } from "../../../components/InstabugButtons";
 import { WalletStyles } from "../../../components/styles/wallet";
 import AppHeader from "../../../components/ui/AppHeader";
 import FooterWithButtons from "../../../components/ui/FooterWithButtons";
-import CardComponent from "../../../components/wallet/card";
+import CardComponent from "../../../components/wallet/card/CardComponent";
 import { LogoPosition } from "../../../components/wallet/card/Logo";
 import PaymentBannerComponent from "../../../components/wallet/PaymentBannerComponent";
 import I18n from "../../../i18n";
@@ -41,6 +41,10 @@ import {
 import { walletsSelector } from "../../../store/reducers/wallet/wallets";
 import { Wallet } from "../../../types/pagopa";
 
+type NavigationParams = Readonly<{
+  paymentCompleted: boolean;
+}>;
+
 type ReduxMappedStateProps =
   | Readonly<{
       valid: false;
@@ -57,11 +61,9 @@ type ReduxMappedDispatchProps = Readonly<{
   showSummary: () => void;
 }>;
 
-type OwnProps = Readonly<{
-  navigation: NavigationScreenProp<NavigationState>;
-}>;
-
-type Props = OwnProps & ReduxMappedStateProps & ReduxMappedDispatchProps;
+type Props = ReduxMappedStateProps &
+  ReduxMappedDispatchProps &
+  NavigationInjectedProps<NavigationParams>;
 
 class PickPaymentMethodScreen extends React.Component<Props> {
   public shouldComponentUpdate(nextProps: Props) {
@@ -109,7 +111,7 @@ class PickPaymentMethodScreen extends React.Component<Props> {
           </Right>
         </AppHeader>
         <Content noPadded={true}>
-          <PaymentBannerComponent navigation={this.props.navigation} />
+          <PaymentBannerComponent />
 
           <View style={WalletStyles.paddedLR}>
             <View spacer={true} />
@@ -134,13 +136,17 @@ class PickPaymentMethodScreen extends React.Component<Props> {
               dataArray={wallets as any[]} // tslint:disable-line: readonly-array
               renderRow={(item): React.ReactElement<any> => (
                 <CardComponent
-                  navigation={this.props.navigation}
                   item={item}
                   menu={false}
                   favorite={false}
                   lastUsage={false}
                   mainAction={confirmPaymentMethod}
                   logoPosition={LogoPosition.TOP}
+                  navigateToDetails={() =>
+                    this.props.navigation.navigate(
+                      ROUTES.WALLET_CARD_TRANSACTIONS
+                    )
+                  }
                 />
               )}
             />

--- a/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
@@ -26,6 +26,7 @@ import { LogoPosition } from "../../../components/wallet/card/Logo";
 import PaymentBannerComponent from "../../../components/wallet/PaymentBannerComponent";
 import I18n from "../../../i18n";
 import ROUTES from "../../../navigation/routes";
+import { navigateToWalletTransactionsScreen } from "../../../store/actions/navigation";
 import { Dispatch } from "../../../store/actions/types";
 import {
   paymentRequestConfirmPaymentMethod,
@@ -136,15 +137,15 @@ class PickPaymentMethodScreen extends React.Component<Props> {
               dataArray={wallets as any[]} // tslint:disable-line: readonly-array
               renderRow={(item): React.ReactElement<any> => (
                 <CardComponent
-                  item={item}
+                  wallet={item}
                   menu={false}
                   favorite={false}
                   lastUsage={false}
                   mainAction={confirmPaymentMethod}
                   logoPosition={LogoPosition.TOP}
-                  navigateToCardTransactions={() =>
-                    this.props.navigation.navigate(
-                      ROUTES.WALLET_CARD_TRANSACTIONS
+                  navigateToWalletTransactions={(selectedWallet: Wallet) =>
+                    this.props.navigation.dispatch(
+                      navigateToWalletTransactionsScreen({ selectedWallet })
                     )
                   }
                 />

--- a/ts/store/actions/navigation.ts
+++ b/ts/store/actions/navigation.ts
@@ -14,6 +14,7 @@ import ROUTES from "../../navigation/routes";
 import { MessageDetailScreen } from "../../screens/messages/MessageDetailScreen";
 import Checkout3DsScreen from "../../screens/wallet/Checkout3DsScreen";
 import TransactionDetailsScreen from "../../screens/wallet/TransactionDetailsScreen";
+import TransactionsScreen from "../../screens/wallet/TransactionsScreen";
 
 export const navigationRestore = createStandardAction("NAVIGATION_RESTORE")<
   NavigationState
@@ -105,5 +106,13 @@ export const navigateToWalletCheckout3dsScreen = (
 ) =>
   NavigationActions.navigate({
     routeName: ROUTES.WALLET_CHECKOUT_3DS_SCREEN,
+    params
+  });
+
+export const navigateToWalletTransactionsScreen = (
+  params: InferNavigationParams<typeof TransactionsScreen>
+) =>
+  NavigationActions.navigate({
+    routeName: ROUTES.WALLET_CARD_TRANSACTIONS,
     params
   });

--- a/ts/store/actions/navigation.ts
+++ b/ts/store/actions/navigation.ts
@@ -7,11 +7,21 @@ import {
 } from "react-navigation";
 import { ActionType, createStandardAction } from "typesafe-actions";
 
+import { InferNavigationParams } from "../../types/react";
+
 import ROUTES from "../../navigation/routes";
+
+import { MessageDetailScreen } from "../../screens/messages/MessageDetailScreen";
+import Checkout3DsScreen from "../../screens/wallet/Checkout3DsScreen";
+import TransactionDetailsScreen from "../../screens/wallet/TransactionDetailsScreen";
 
 export const navigationRestore = createStandardAction("NAVIGATION_RESTORE")<
   NavigationState
 >();
+
+export type NavigationActions =
+  | NavigationAction
+  | ActionType<typeof navigationRestore>;
 
 export const resetToAuthenticationRoute: NavigationResetAction = StackActions.reset(
   {
@@ -56,7 +66,9 @@ export const navigateToBackgroundScreen = NavigationActions.navigate({
 
 export const navigateBack = NavigationActions.back;
 
-export const navigateToMessageDetailScreenAction = (messageId: string) =>
+export const navigateToMessageDetailScreenAction = (
+  params: InferNavigationParams<typeof MessageDetailScreen>
+) =>
   StackActions.reset({
     key: "StackRouterRoot",
     index: 0,
@@ -67,15 +79,31 @@ export const navigateToMessageDetailScreenAction = (messageId: string) =>
           routeName: ROUTES.MESSAGES_NAVIGATOR,
           action: NavigationActions.navigate({
             routeName: ROUTES.MESSAGE_DETAIL,
-            params: {
-              messageId
-            }
+            params
           })
         })
       })
     ]
   });
 
-export type NavigationActions =
-  | NavigationAction
-  | ActionType<typeof navigationRestore>;
+// TODO: this should use StackActions.reset
+// to reset the navigation. Right now, the
+// "back" option is not allowed -- so the user cannot
+// get back to previous screens, but the navigation
+// stack should be cleaned right here
+// @https://www.pivotaltracker.com/story/show/159300579
+export const navigateToTransactionDetailsScreen = (
+  params: InferNavigationParams<typeof TransactionDetailsScreen>
+) =>
+  NavigationActions.navigate({
+    routeName: ROUTES.WALLET_TRANSACTION_DETAILS,
+    params
+  });
+
+export const navigateToWalletCheckout3dsScreen = (
+  params: InferNavigationParams<typeof Checkout3DsScreen>
+) =>
+  NavigationActions.navigate({
+    routeName: ROUTES.WALLET_CHECKOUT_3DS_SCREEN,
+    params
+  });

--- a/ts/store/actions/wallet/payment.ts
+++ b/ts/store/actions/wallet/payment.ts
@@ -13,17 +13,6 @@ import { Psp, Wallet } from "../../../types/pagopa";
 
 export const resetPaymentState = createStandardAction("PAYMENT_COMPLETED")();
 
-type PaymentUpdatePspInStatePayload = Readonly<{
-  walletId: number;
-  psp: Psp; // pspId
-}>;
-
-// TODO: temporary action until integration with pagoPA occurs
-// @https://www.pivotaltracker.com/story/show/159494746
-export const paymentUpdatePspInState = createStandardAction(
-  "PAYMENT_UPDATE_PSP_IN_STATE"
-)<PaymentUpdatePspInStatePayload>();
-
 export const startPaymentSaga = createStandardAction("PAYMENT_REQUEST")();
 
 /**
@@ -199,7 +188,6 @@ export type PaymentActions =
   | ActionType<typeof paymentRequestPickPsp>
   | ActionType<typeof setPaymentStateToPickPsp>
   | ActionType<typeof paymentUpdatePsp>
-  | ActionType<typeof paymentUpdatePspInState> // TODO: temporary, until integration with pagoPA occurs @https://www.pivotaltracker.com/story/show/159494746
   | ActionType<typeof paymentRequestCompletion>
   | ActionType<typeof resetPaymentState>
   | ActionType<typeof goBackOnePaymentState>

--- a/ts/store/actions/wallet/transactions.ts
+++ b/ts/store/actions/wallet/transactions.ts
@@ -9,7 +9,6 @@ import { Transaction } from "../../../types/pagopa";
 export type TransactionsActions =
   | ActionType<typeof fetchTransactionsSuccess>
   | ActionType<typeof fetchTransactionsRequest>
-  | ActionType<typeof selectTransactionForDetails>
   | ActionType<typeof storeNewTransaction>
   | ActionType<typeof fetchTransactionsFailure>;
 
@@ -29,10 +28,5 @@ export const fetchTransactionsRequest = createStandardAction(
 
 export const storeNewTransaction = createAction(
   "PAYMENT_STORE_NEW_TRANSACTION",
-  resolve => (transaction: Transaction) => resolve(transaction)
-);
-
-export const selectTransactionForDetails = createAction(
-  "SELECT_TRANSACTION_FOR_DETAILS",
   resolve => (transaction: Transaction) => resolve(transaction)
 );

--- a/ts/store/actions/wallet/wallets.ts
+++ b/ts/store/actions/wallet/wallets.ts
@@ -10,7 +10,6 @@ import { CreditCard, Wallet } from "../../../types/pagopa";
 export type WalletsActions =
   | ActionType<typeof fetchWalletsRequest>
   | ActionType<typeof fetchWalletsSuccess>
-  | ActionType<typeof selectWalletForDetails>
   | ActionType<typeof setFavoriteWallet>
   | ActionType<typeof storeCreditCardData>
   | ActionType<typeof creditCardDataCleanup>
@@ -34,10 +33,6 @@ export const fetchWalletsFailure = createAction(
   "FETCH_WALLETS_FAILURE",
   resolve => (error: Error) => resolve(error)
 );
-
-export const selectWalletForDetails = createStandardAction(
-  "SELECT_WALLET_FOR_DETAILS"
-)<number>();
 
 export const setFavoriteWallet = createAction(
   "SET_FAVORITE_WALLET",

--- a/ts/store/helpers/indexer.ts
+++ b/ts/store/helpers/indexer.ts
@@ -1,33 +1,26 @@
 import { entries } from "lodash";
 
-interface IStringKeyedObject {
-  [key: string]: any;
-}
-
 /**
  * represents a "list" of objects that have
  * been indexed by a specific property
  */
 export interface IndexedById<T> {
-  [key: string]: T;
-  [key: number]: T;
+  [key: string]: T | undefined;
+  [key: number]: T | undefined;
 }
 
 /**
  * Returns an indexed object generated from a list of objects:
  * - V: object with a user-specified index (e.g. Wallet -> idWallet)
  * @param lst   input list to be indexed (e.g. [ { id: 1, payload: "X" }, { id: 42, payload: "Y" } ] )
- * @param key   key to be used to extract the index from `lst`
+ * @param key   function to extract the key from T
  * @returns     indexed object (e.g. { 1: { id: 1, payload: "X" }, 42: { id: 42, payload: "Y" } } )
  */
-export const toIndexed = <T extends IStringKeyedObject, K extends keyof T>(
+export const toIndexed = <T>(
   lst: ReadonlyArray<T>,
-  key: K
-): IndexedById<T> => {
-  return lst.reduce((o, obj) => ({ ...o, [obj[key]]: obj }), {} as IndexedById<
-    T
-  >);
-};
+  key: (_: T) => string | number
+): IndexedById<T> =>
+  lst.reduce((o, obj) => ({ ...o, [key(obj)]: obj }), {} as IndexedById<T>);
 
 /**
  * Adds a new object to an indexed "list" of objects
@@ -38,11 +31,14 @@ export const toIndexed = <T extends IStringKeyedObject, K extends keyof T>(
  * @param key     key used to extract the index from `newObj`
  * @returns       new indexed object, with the elements from indexed and newObj
  */
-export const addToIndexed = <T extends IStringKeyedObject, K extends keyof T>(
+export const addToIndexed = <T>(
   indexed: IndexedById<T>,
   newObj: T,
-  key: K
+  key: (_: T) => string | number
 ): IndexedById<T> =>
-  entries(indexed).reduce((o, [k, v]: [string, T]) => ({ ...o, [k]: v }), {
-    [newObj[key]]: newObj
-  } as IndexedById<T>);
+  entries(indexed).reduce(
+    (o, [k, v]: [string, T | undefined]) => ({ ...o, [k]: v }),
+    {
+      [key(newObj)]: newObj
+    } as IndexedById<T>
+  );

--- a/ts/store/reducers/wallet/transactions.ts
+++ b/ts/store/reducers/wallet/transactions.ts
@@ -25,9 +25,10 @@ const TRANSACTIONS_INITIAL_STATE: TransactionsState = {
 };
 
 // selectors
-export const getTransactions = (
-  state: GlobalState
-): ReadonlyArray<Transaction> => values(state.wallet.transactions.transactions);
+export const getTransactions = (state: GlobalState) =>
+  values(state.wallet.transactions.transactions).filter(
+    _ => _ !== undefined
+  ) as ReadonlyArray<Transaction>;
 
 export const latestTransactionsSelector = createSelector(
   getTransactions,
@@ -58,13 +59,17 @@ const reducer = (
     case getType(fetchTransactionsSuccess):
       return {
         ...state,
-        transactions: toIndexed(action.payload.map(cleanDescription), "id")
+        transactions: toIndexed(action.payload.map(cleanDescription), _ => _.id)
       };
 
     case getType(storeNewTransaction):
       return {
         ...state,
-        transactions: addToIndexed(state.transactions, action.payload, "id")
+        transactions: addToIndexed(
+          state.transactions,
+          action.payload,
+          _ => _.id
+        )
       };
 
     default:

--- a/ts/store/reducers/wallet/wallets.ts
+++ b/ts/store/reducers/wallet/wallets.ts
@@ -8,11 +8,9 @@ import { createSelector } from "reselect";
 import { getType } from "typesafe-actions";
 import { CreditCard, Wallet } from "../../../types/pagopa";
 import { Action } from "../../actions/types";
-import { paymentUpdatePspInState } from "../../actions/wallet/payment";
 import {
   creditCardDataCleanup,
   fetchWalletsSuccess,
-  selectWalletForDetails,
   setFavoriteWallet,
   storeCreditCardData
 } from "../../actions/wallet/wallets";
@@ -20,28 +18,31 @@ import { IndexedById, toIndexed } from "../../helpers/indexer";
 import { GlobalState } from "../types";
 
 export type WalletsState = Readonly<{
-  list: IndexedById<Wallet>;
-  selectedWalletId: Option<number>;
+  walletById: IndexedById<Wallet | undefined>;
   favoriteWalletId: Option<number>;
   newCreditCard: Option<CreditCard>;
 }>;
 
 const WALLETS_INITIAL_STATE: WalletsState = {
-  list: {},
-  selectedWalletId: none,
+  walletById: {},
   favoriteWalletId: none,
   newCreditCard: none
 };
 
 // selectors
-export const getWallets = (state: GlobalState) => state.wallet.wallets.list;
-export const getSelectedWalletId = (state: GlobalState) =>
-  state.wallet.wallets.selectedWalletId;
+export const getWalletsById = (state: GlobalState) =>
+  state.wallet.wallets.walletById;
+
+export const getWallets = createSelector(
+  getWalletsById,
+  wx => values(wx).filter(_ => _ !== undefined) as ReadonlyArray<Wallet>
+);
+
 export const getFavoriteWalletId = (state: GlobalState) =>
   state.wallet.wallets.favoriteWalletId;
 export const getFavoriteWallet = (state: GlobalState) =>
   state.wallet.wallets.favoriteWalletId.mapNullable(
-    walletId => state.wallet.wallets.list[walletId]
+    walletId => state.wallet.wallets.walletById[walletId]
   );
 
 export const getNewCreditCard = (state: GlobalState) =>
@@ -51,8 +52,8 @@ export const walletsSelector = createSelector(
   getWallets,
   // define whether an order among cards needs to be established
   // (e.g. by insertion date, expiration date, ...)
-  (wallets: IndexedById<Wallet>): ReadonlyArray<Wallet> =>
-    values(wallets).sort(
+  (wallets: ReturnType<typeof getWallets>): ReadonlyArray<Wallet> =>
+    [...wallets].sort(
       // sort by date, descending
       // if both dates are undefined -> 0
       // if either is undefined, it is considered as used "infinitely" long ago
@@ -74,23 +75,14 @@ export const getWalletFromId = (
 ): Option<Wallet> =>
   walletId.mapNullable(wId => values(wallets).find(c => c.idWallet === wId));
 
-export const selectedWalletSelector = createSelector(
-  getSelectedWalletId,
-  getWallets,
-  getWalletFromId
-);
-
-export const specificWalletSelector = (walletId: number) =>
-  createSelector(() => some(walletId), getWallets, getWalletFromId);
-
 export const feeExtractor = (w: Wallet): AmountInEuroCents | undefined =>
   w.psp === undefined
     ? undefined
     : (("0".repeat(10) + `${w.psp.fixedCost.amount}`) as AmountInEuroCents);
 
 export const walletCountSelector = createSelector(
-  getWallets,
-  (wallets: IndexedById<Wallet>) => Object.keys(wallets).length
+  getWalletsById,
+  (wallets: ReturnType<typeof getWalletsById>) => Object.keys(wallets).length
 );
 
 // reducer
@@ -102,13 +94,7 @@ const reducer = (
     case getType(fetchWalletsSuccess):
       return {
         ...state,
-        list: toIndexed(action.payload, "idWallet")
-      };
-
-    case getType(selectWalletForDetails):
-      return {
-        ...state,
-        selectedWalletId: some(action.payload)
+        walletById: toIndexed(action.payload, "idWallet")
       };
 
     case getType(setFavoriteWallet):
@@ -135,23 +121,6 @@ const reducer = (
       return {
         ...state,
         newCreditCard: none
-      };
-
-    // TODO: temporary, until the integration with pagoPA
-    // (then, the psp will be updated on the server side,
-    // and, by fetching the existing cards the psp will be
-    // automatically updated)
-    case getType(paymentUpdatePspInState):
-      return {
-        ...state,
-        list: {
-          ...state.list,
-          [action.payload.walletId]: {
-            ...state.list[action.payload.walletId],
-            idPsp: action.payload.psp.id,
-            psp: action.payload.psp
-          }
-        }
       };
 
     default:

--- a/ts/store/reducers/wallet/wallets.ts
+++ b/ts/store/reducers/wallet/wallets.ts
@@ -18,7 +18,7 @@ import { IndexedById, toIndexed } from "../../helpers/indexer";
 import { GlobalState } from "../types";
 
 export type WalletsState = Readonly<{
-  walletById: IndexedById<Wallet | undefined>;
+  walletById: IndexedById<Wallet>;
   favoriteWalletId: Option<number>;
   newCreditCard: Option<CreditCard>;
 }>;
@@ -73,7 +73,9 @@ export const getWalletFromId = (
   walletId: Option<number>,
   wallets: IndexedById<Wallet>
 ): Option<Wallet> =>
-  walletId.mapNullable(wId => values(wallets).find(c => c.idWallet === wId));
+  walletId.mapNullable(wId =>
+    values(wallets).find(c => c !== undefined && c.idWallet === wId)
+  );
 
 export const feeExtractor = (w: Wallet): AmountInEuroCents | undefined =>
   w.psp === undefined
@@ -94,7 +96,7 @@ const reducer = (
     case getType(fetchWalletsSuccess):
       return {
         ...state,
-        walletById: toIndexed(action.payload, "idWallet")
+        walletById: toIndexed(action.payload, _ => _.idWallet)
       };
 
     case getType(setFavoriteWallet):

--- a/ts/types/react.ts
+++ b/ts/types/react.ts
@@ -1,4 +1,8 @@
 import { Component, ComponentType, StatelessComponent } from "react";
+import {
+  NavigationInjectedProps,
+  NavigationScreenProps
+} from "react-navigation";
 
 /**
  * Evaluates to the Props type of a React component
@@ -8,3 +12,13 @@ export type ComponentProps<C> = C extends StatelessComponent<infer P1>
   : C extends Component<infer P2>
     ? P2
     : C extends ComponentType<infer P3> ? P3 : never;
+
+/**
+ * Infers the type of the navigation params of a component
+ */
+export type InferNavigationParams<
+  C,
+  P = ComponentProps<C>
+> = P extends NavigationInjectedProps<infer N>
+  ? N
+  : P extends NavigationScreenProps<infer N1> ? N1 : never;


### PR DESCRIPTION
Information about wallet and transaction selected for the details screens is now passed via navigation parameters (in a type safe way using custom navigation actions and navigation param types).

Also adds handling the case where a transaction is linked to a wallet that has been deleted (it seemed to me this case wasn't handled).