### PR TITLE
[161198605] Set card as favourite if required on save

### DIFF
--- a/ts/sagas/wallet.ts
+++ b/ts/sagas/wallet.ts
@@ -201,7 +201,7 @@ function* addCreditCard(
   const wallet: NullableWallet = {
     idWallet: null,
     type: "CREDIT_CARD",
-    favourite: null,
+    favourite: action.payload.setAsFavorite,
     creditCard: action.payload.creditCard,
     psp: undefined
   };

--- a/ts/types/pagopa.ts
+++ b/ts/types/pagopa.ts
@@ -105,11 +105,7 @@ export type Wallet = t.TypeOf<typeof Wallet>;
 /**
  * A Wallet that has not being saved yet
  */
-export type NullableWallet = ReplaceProp1<
-  Wallet,
-  "idWallet" | "favourite",
-  null
->;
+export type NullableWallet = ReplaceProp1<Wallet, "idWallet", null>;
 
 /**
  * A refined Transaction


### PR DESCRIPTION
@cloudify 
The value of the favourite switch was not passed to the API request but also now that is passed the API return value has still `favourite = false` please investigate API-side.

REQUEST PAYLOAD
```
{
    "data": {
        "creditCard": {
            "expireMonth": "12",
            "expireYear": "22",
            "holder": "Mario Rossi",
            "pan": "XXXXXXXX99996934",
            "securityCode": "543"
        },
        "favourite": true,
        "idWallet": null,
        "type": "CREDIT_CARD"
    }
}
```

RESPONSE PAYLOAD
```
{
    "data": {
        "creditCard": {
            "brandLogo": "...generic.png",
            "expireMonth": "12",
            "expireYear": "22",
            "flag3dsVerified": false,
            "holder": "Mario Rossi",
            "id": 6026,
            "pan": "************6934"
        },
        "favourite": false,
        "idWallet": 7205,
        "pspEditable": true,
        "type": "CREDIT_CARD"
    }
}
```
