### PR TITLE
[#161484154] Do not start a payment if wallets are not available

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -233,6 +233,10 @@ wallet:
   creditcards: Credit Cards
   paymentMethods: Payment methods
   paymentMethod: Payment method
+  walletLoadMessage: Loading payment methods...
+  walletLoadFailure: Loading payment methods has failed!
+  transactionsLoadMessage: Loading transactions...
+  transactionsLoadFailure: Loading transactions has failed!
   pickPaymentMethod:
     unavailable:
       title: This payment method is not available at this time

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -240,6 +240,10 @@ wallet:
   creditcards: Carte di Credito
   paymentMethods: Metodi di pagamento
   paymentMethod: Metodo di pagamento
+  walletLoadMessage: Carico i metodi di pagamento...
+  walletLoadFailure: Non è stato possibile caricare i metodi di pagamento.
+  transactionsLoadMessage: Carico lo storico delle transazioni...
+  transactionsLoadFailure: Non è stato possibile caricare lo storico delle transazioni.
   pickPaymentMethod:
     unavailable:
       title: Questo metodo di pagamento non è ancora disponibile

--- a/ts/components/ui/BoxedRefreshIndicator.tsx
+++ b/ts/components/ui/BoxedRefreshIndicator.tsx
@@ -11,12 +11,15 @@ const styles = StyleSheet.create({
   }
 });
 
-export default class BoxedRefreshIndicator extends React.Component {
-  public render() {
-    return (
-      <View style={styles.refreshBox}>
-        <RefreshIndicator />
-      </View>
-    );
-  }
+interface Props {
+  caption?: React.ReactNode;
 }
+
+const BoxedRefreshIndicator: React.SFC<Props> = props => (
+  <View style={styles.refreshBox}>
+    <RefreshIndicator />
+    {props.caption ? props.caption : null}
+  </View>
+);
+
+export default BoxedRefreshIndicator;

--- a/ts/components/wallet/TransactionsList.tsx
+++ b/ts/components/wallet/TransactionsList.tsx
@@ -88,7 +88,11 @@ export default class TransactionsList extends React.Component<Props> {
 
   public render(): React.ReactNode {
     if (pot.isLoading(this.props.transactions)) {
-      return <BoxedRefreshIndicator />;
+      return (
+        <BoxedRefreshIndicator
+          caption={<Text>{I18n.t("wallet.transactionsLoadMessage")}</Text>}
+        />
+      );
     }
 
     const transactions = pot.getOrElse(this.props.transactions, []);

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -143,7 +143,32 @@ class WalletHomeScreen extends React.Component<Props, never> {
       <View>
         {this.header()}
         <View spacer={true} />
-        <BoxedRefreshIndicator />
+        <BoxedRefreshIndicator
+          caption={
+            <Text style={[WalletStyles.white, styles.inLineSpace]}>
+              {I18n.t("wallet.walletLoadMessage")}
+            </Text>
+          }
+        />
+      </View>
+    );
+  }
+
+  private errorWalletsHeader() {
+    return (
+      <View>
+        {this.header()}
+        <View spacer={true} />
+        <Text note={true} style={[WalletStyles.white, styles.inLineSpace]}>
+          {I18n.t("wallet.walletLoadFailure")}
+        </Text>
+        <View spacer={true} />
+        <Button block={true} danger={true} onPress={this.props.loadWallets}>
+          <Text style={WalletStyles.addPaymentMethodText}>
+            {I18n.t("global.buttons.retry")}
+          </Text>
+        </Button>
+        <View spacer={true} />
       </View>
     );
   }
@@ -161,9 +186,11 @@ class WalletHomeScreen extends React.Component<Props, never> {
     const wallets = pot.getOrElse(potWallets, []);
     const headerContents = pot.isLoading(potWallets)
       ? this.loadingWalletsHeader()
-      : wallets.length > 0
-        ? this.withCardsHeader()
-        : this.withoutCardsHeader();
+      : pot.isError(potWallets)
+        ? this.errorWalletsHeader()
+        : wallets.length > 0
+          ? this.withCardsHeader()
+          : this.withoutCardsHeader();
 
     return (
       <WalletLayout
@@ -179,17 +206,37 @@ class WalletHomeScreen extends React.Component<Props, never> {
             />
           )
         }
-        onNewPaymentPress={this.props.navigateToPaymentScanQrCode}
+        onNewPaymentPress={
+          pot.isSome(potWallets)
+            ? this.props.navigateToPaymentScanQrCode
+            : undefined
+        }
         allowGoBack={false}
       >
-        <TransactionsList
-          title={I18n.t("wallet.latestTransactions")}
-          totalAmount={I18n.t("wallet.total")}
-          transactions={potTransactions}
-          navigateToTransactionDetails={
-            this.props.navigateToTransactionDetailsScreen
-          }
-        />
+        {pot.isError(potTransactions) ? (
+          <React.Fragment>
+            <View spacer={true} />
+            <Text note={true} style={[WalletStyles.white, styles.inLineSpace]}>
+              {I18n.t("wallet.transactionsLoadFailure")}
+            </Text>
+            <Button
+              block={true}
+              danger={true}
+              onPress={this.props.loadTransactions}
+            >
+              <Text>{I18n.t("global.buttons.retry")}</Text>
+            </Button>
+          </React.Fragment>
+        ) : (
+          <TransactionsList
+            title={I18n.t("wallet.latestTransactions")}
+            totalAmount={I18n.t("wallet.total")}
+            transactions={potTransactions}
+            navigateToTransactionDetails={
+              this.props.navigateToTransactionDetailsScreen
+            }
+          />
+        )}
       </WalletLayout>
     );
   }


### PR DESCRIPTION
Not 100% perfect as payments can still be started from a message, but not yet clear from a UX point of view how we can block that when wallets are not yet loaded. Also in the case of a message, the wallet home screen gets rendered when navigating to the payment flow.