### PR TITLE
Fix "inlineOneThird" style.

### DIFF
--- a/ts/theme/components/FooterWithButtons.ts
+++ b/ts/theme/components/FooterWithButtons.ts
@@ -7,9 +7,9 @@ export default (): Theme => ({
       flexDirection: "row",
       "NativeBase.Button": {
         flex: 1,
+        alignContent: "center",
         ".primary": {
-          flex: 3,
-          alignContent: "center"
+          flex: 2
         }
       }
     }


### PR DESCRIPTION
This PR fixes the style applied to `<FooterWithButtons>` with `inlineOneThird` prop to actually be 1/3 and 2/3.

![screenshot_1541071651](https://user-images.githubusercontent.com/11299464/47849431-db2f1780-ddd1-11e8-99db-26270b69f665.png)
