### PR TITLE
[#161447989] Fix buttons style in confirm method screen.

### DIFF
--- a/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
@@ -79,6 +79,9 @@ const styles = StyleSheet.create({
     flex: 1,
     alignContent: "center"
   },
+  childTwice: {
+    flex: 2
+  },
   parent: {
     flexDirection: "row"
   }
@@ -241,20 +244,20 @@ class ConfirmPaymentMethodScreen extends React.Component<Props, never> {
             <Button
               style={styles.child}
               block={true}
+              cancel={true}
+              onPress={this.props.onCancel}
+            >
+              <Text>{I18n.t("global.buttons.cancel")}</Text>
+            </Button>
+            <View hspacer={true} />
+            <Button
+              style={[styles.child, styles.childTwice]}
+              block={true}
               light={true}
               bordered={true}
               onPress={_ => this.props.pickPaymentMethod()}
             >
               <Text>{I18n.t("wallet.ConfirmPayment.change")}</Text>
-            </Button>
-            <View hspacer={true} />
-            <Button
-              style={styles.child}
-              block={true}
-              cancel={true}
-              onPress={this.props.onCancel}
-            >
-              <Text>{I18n.t("global.buttons.cancel")}</Text>
             </Button>
           </View>
         </View>


### PR DESCRIPTION
![screenshot_1541241783](https://user-images.githubusercontent.com/11299464/47951237-224a1380-df5e-11e8-8eb8-0c4915b1d470.png)

(Don't mind the "?"s and the "NaN"s, I used mocked data to show this screen)