### PR TITLE
[#163254541] Fixes infinite loop when session is expired on startup.

### DIFF
--- a/ts/sagas/profile.ts
+++ b/ts/sagas/profile.ts
@@ -47,6 +47,12 @@ export function* loadProfile(
       return some(response.value);
     }
 
+    if (response && response.status === 401) {
+      // in case we got an expired session while loading the profile, we reset
+      // the session
+      yield put(sessionExpired());
+    }
+
     throw response ? response.value : Error(I18n.t("profile.errors.load"));
   } catch (error) {
     yield put(profileLoadFailure(error));


### PR DESCRIPTION
Bug should only manifest in iOS simulator since there is no call to the backend for configuring push notifications.