### PR TITLE
[#163824330] Optimize MessageState[] selector

### DIFF
--- a/ts/screens/messages/MessageListScreen.tsx
+++ b/ts/screens/messages/MessageListScreen.tsx
@@ -11,7 +11,7 @@ import I18n from "../../i18n";
 import { loadMessages } from "../../store/actions/messages";
 import { navigateToMessageDetailScreenAction } from "../../store/actions/navigation";
 import { ReduxProps } from "../../store/actions/types";
-import { orderedMessagesStateSelector as sortedMessagesStateSelector } from "../../store/reducers/entities/messages";
+import { lexicallyOrderedMessagesStateSelector } from "../../store/reducers/entities/messages";
 import { servicesByIdSelector } from "../../store/reducers/entities/services/servicesById";
 import { GlobalState } from "../../store/reducers/types";
 import variables from "../../theme/variables";
@@ -95,7 +95,7 @@ class MessageListScreen extends React.Component<Props, never> {
 }
 
 const mapStateToProps = (state: GlobalState) => ({
-  potMessages: sortedMessagesStateSelector(state),
+  potMessages: lexicallyOrderedMessagesStateSelector(state),
   servicesById: servicesByIdSelector(state),
   paymentByRptId: state.entities.paymentByRptId
 });

--- a/ts/store/reducers/entities/messages/index.ts
+++ b/ts/store/reducers/entities/messages/index.ts
@@ -1,5 +1,5 @@
 /**
- * Notifications reducer
+ * Messages combined reducer
  */
 
 import * as pot from "italia-ts-commons/lib/pot";
@@ -30,20 +30,27 @@ const reducer = combineReducers<MessagesState, Action>({
 // Selectors
 
 /**
- * Returns messages inversely lexically sorted by ID.
- *
- * Note that message IDs are ULIDs (https://github.com/ulid/spec) so this
- * should return messages sorted from most to least recent.
+ * Returns array of messages IDs inversely lexically ordered.
  */
-export const orderedMessagesStateSelector = createSelector(
-  messagesAllIdsSelector, // FIXME: not needed, we can extract the IDs from messageStateById
+export const lexicallyOrderedMessagesIds = createSelector(
+  messagesAllIdsSelector,
+  potIds =>
+    pot.map(potIds, ids =>
+      [...ids].sort((a: string, b: string) => b.localeCompare(a))
+    )
+);
+
+/**
+ * A selector that using the inversely lexically ordered messages IDs
+ * returned by lexicallyOrderedMessagesIds returns an array of the
+ * mapped/related messages.
+ */
+export const lexicallyOrderedMessagesStateSelector = createSelector(
+  lexicallyOrderedMessagesIds,
   messagesStateByIdSelector,
   (potIds, messageStateById) =>
     pot.map(potIds, ids =>
-      [...ids]
-        .sort((a: string, b: string) => b.localeCompare(a))
-        .map(messageId => messageStateById[messageId])
-        .filter(isDefined)
+      ids.map(messageId => messageStateById[messageId]).filter(isDefined)
     )
 );
 


### PR DESCRIPTION
The current implementation:

```
export const orderedMessagesStateSelector = createSelector(
  messagesAllIdsSelector, // FIXME: not needed, we can extract the IDs from messageStateById
  messagesStateByIdSelector,
  (potIds, messageStateById) =>
    pot.map(potIds, ids =>
      [...ids]
        .sort((a: string, b: string) => b.localeCompare(a))
        .map(messageId => messageStateById[messageId])
        .filter(isDefined)
    )
);
```

The problem here is that when messagesStateByIdSelector return a new value (ex: a message is loaded or the read status changed) the ids sorting is applied for no reason (the ids are not changed).

To solve i have splitted the function into 2 selector, the second one is using the first.

```
/**
 * Returns array of messages IDs inversely lexically ordered.
 */
export const lexicallyOrderedMessagesIds = createSelector(
  messagesAllIdsSelector,
  potIds =>
    pot.map(potIds, ids =>
      [...ids].sort((a: string, b: string) => b.localeCompare(a))
    )
);

/**
 * A selector that using the inversely lexically ordered messages IDs
 * returned by lexicallyOrderedMessagesIds returns an array of the
 * mapped/related messages.
 */
export const lexicallyOrderedMessagesStateSelector = createSelector(
  lexicallyOrderedMessagesIds,
  messagesStateByIdSelector,
  (potIds, messageStateById) =>
    pot.map(potIds, ids =>
      ids.map(messageId => messageStateById[messageId]).filter(isDefined)
    )
);
```

Debug message as prrof of the optimization with the Current and Optimized solution

**CURRENT**
![current](https://user-images.githubusercontent.com/30595520/52481812-e2737780-2baf-11e9-9817-3277ebdf71b9.png)

**OPTIMIZED**
![optimized](https://user-images.githubusercontent.com/30595520/52481838-fd45ec00-2baf-11e9-9732-95a78f1b1633.png)

The logic can be optimized further but can be done later.


